### PR TITLE
Fixed terraform-related errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # terraform files
 **/.terraform*
 *.tfstate
-*.tfstate.*
+*.tfstate*
 *.tfvars
 
 # node wallets

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # terraform files
-**/.terraform/*
+**/.terraform*
 *.tfstate
 *.tfstate.*
 *.tfvars

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # terraform files
 **/.terraform*
 *.tfstate
-*.tfstate*
+*tfstate*
 *.tfvars
 
 # node wallets

--- a/skale-nodes/ansible/create.sh
+++ b/skale-nodes/ansible/create.sh
@@ -6,7 +6,8 @@ cd terraform/aws
 rm -f hosts
 rm -f terraform.tfstate.backup
 mkdir -p tfstate_backup
-mv terraform.tfstate tfstate_backup/terraform.tfstate-$(date +"%F-%T")
+mv terraform.tfstate tfstate_backup/terraform.tfstate-$(date +"%F-%T") > /dev/null 2>&1 || \
+echo "No tfstate present"
 TF_VAR_NUMBER=$NODES_NUMBER terraform apply -auto-approve
 echo 'Nodes machines created'
 sort hosts >> ../../inventory/hosts

--- a/skale-nodes/ansible/terraform/aws/main.tf
+++ b/skale-nodes/ansible/terraform/aws/main.tf
@@ -74,7 +74,6 @@ resource "aws_spot_instance_request" "node" {
 
   root_block_device {
     volume_size = var.root_volume_size
-    volume_type = var.root_volume_type
   }
 
   tags = {
@@ -95,7 +94,6 @@ resource "aws_instance" "node" {
 
   root_block_device {
     volume_size = var.root_volume_size
-    volume_type = var.root_volume_type
   }
 
   tags = {

--- a/skale-nodes/ansible/terraform/aws/variables.tf
+++ b/skale-nodes/ansible/terraform/aws/variables.tf
@@ -22,8 +22,6 @@ variable "zones" {}
 
 variable "root_volume_size" {}
 
-variable "root_volume_type" {}
-
 variable "attached_disk_size" {}
 
 variable "attached_disk_type" {}


### PR DESCRIPTION
Changes:
1) Fixed wrong disk type variable for root disk (can not set root disk type for instance on aws)
2) Fixed create script error when terraform.tfstate not present + added log when it is not present
3) Added tfstate backups and terraform dirs to gitinore
