### PR TITLE
Skale contracts integration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 100
+exclude = .git,__pycache__,docs/source/conf.py,old,build,dist,venv,.venv,node_modules,helper-scripts

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ wallets/*
 # ansible
 skale-nodes/ansible/my-inventory
 skale-nodes/ansible/inventory/
+skale-nodes/ansible/inventory*
 skale-nodes/ansible/files/base-key*.txt
 skale-nodes/ansible/files/dev*
 skale-nodes/ansible/files/authorized_keys

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,4 @@
+line-length = 100
+
+[format]
+quote-style = "single"

--- a/skale-nodes/ansible/backup_schains.yaml
+++ b/skale-nodes/ansible/backup_schains.yaml
@@ -8,6 +8,7 @@
       environment:
         ETH_PRIVATE_KEY: "{{ eth_private_key }}"
         ENDPOINT: "{{ endpoint }}"
+        MANAGER_CONTRACTS: "{{ manager_contracts }}"
         BASE_DIR: "files"
       args:
         executable: python3

--- a/skale-nodes/ansible/cleanup_sgx.yaml
+++ b/skale-nodes/ansible/cleanup_sgx.yaml
@@ -1,5 +1,5 @@
 - name: Cleanup sgx
-  hosts: nodes
+  hosts: sgx
   become: true
   roles:
     - name: Remove all sgx skale software from the machines

--- a/skale-nodes/ansible/cleanup_sgx.yaml
+++ b/skale-nodes/ansible/cleanup_sgx.yaml
@@ -1,5 +1,5 @@
 - name: Cleanup sgx
-  hosts: sgx
+  hosts: nodes
   become: true
   roles:
     - name: Remove all sgx skale software from the machines

--- a/skale-nodes/ansible/files/cleanup_contracts.py
+++ b/skale-nodes/ansible/files/cleanup_contracts.py
@@ -1,7 +1,7 @@
 import logging
 import os
 
-from skale import Skale
+from skale import SkaleManager
 from skale.wallets import Web3Wallet
 from skale.utils.web3_utils import init_web3
 from skale.utils.helper import init_default_logger
@@ -11,12 +11,12 @@ init_default_logger()
 
 BASE_DIR = os.getenv('BASE_DIR')
 ENDPOINT = os.getenv('ENDPOINT')
-ABI_FILEPATH = os.path.join(BASE_DIR, 'manager.json')
+MANAGER_CONTRACTS = os.getenv('MANAGER_CONTRACTS')
 ETH_PRIVATE_KEY = os.getenv('ETH_PRIVATE_KEY')
 
 web3 = init_web3(ENDPOINT)
 wallet = Web3Wallet(ETH_PRIVATE_KEY, web3)
-skale = Skale(ENDPOINT, ABI_FILEPATH, wallet)
+skale = SkaleManager(ENDPOINT, MANAGER_CONTRACTS, wallet)
 
 
 def remove_active_nodes():
@@ -27,10 +27,7 @@ def remove_active_nodes():
 def get_all_schains_names(skale):
     schains_ids = skale.schains_internal.get_all_schains_ids()
     print(schains_ids)
-    names = [
-        skale.schains.get(sid).get('name')
-        for sid in schains_ids
-    ]
+    names = [skale.schains.get(sid).get('name') for sid in schains_ids]
     return names
 
 
@@ -45,5 +42,5 @@ def cleanup():
     remove_active_nodes()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     cleanup()

--- a/skale-nodes/ansible/files/fetch_node_schains.py
+++ b/skale-nodes/ansible/files/fetch_node_schains.py
@@ -22,7 +22,7 @@ import json
 import logging
 import os
 
-from skale import Skale
+from skale import SkaleManager
 from skale.wallets import Web3Wallet
 from skale.utils.helper import ip_from_bytes
 from skale.utils.web3_utils import init_web3
@@ -31,23 +31,20 @@ logger = logging.getLogger(__name__)
 
 BASE_DIR = os.getenv('BASE_DIR')
 ENDPOINT = os.getenv('ENDPOINT')
-ABI_FILEPATH = os.path.join(BASE_DIR, 'manager.json')
+MANAGER_CONTRACTS = os.getenv('MANAGER_CONTRACTS')
 ETH_PRIVATE_KEY = os.getenv('ETH_PRIVATE_KEY')
 
 
 def dropped_irrelevant(node_data):
-    return {
-        'name': node_data['name'],
-        'ip': ip_from_bytes(node_data['ip'])
-    }
+    return {'name': node_data['name'], 'ip': ip_from_bytes(node_data['ip'])}
 
 
 def get_nodes_by_schain(skale, schain):
     node_ids = skale.schains_internal.get_node_ids_for_schain(schain)
-    return sorted([
-        dropped_irrelevant(skale.nodes.get(nid))
-        for nid in node_ids
-    ], key=lambda node: node['name'])
+    return sorted(
+        [dropped_irrelevant(skale.nodes.get(nid)) for nid in node_ids],
+        key=lambda node: node['name'],
+    )
 
 
 def get_all_schains(skale):
@@ -75,11 +72,10 @@ def get_schains_by_nodes(skale, schains, unique_nodes=False):
 def main():
     web3 = init_web3(ENDPOINT)
     wallet = Web3Wallet(ETH_PRIVATE_KEY, web3)
-    skale = Skale(ENDPOINT, ABI_FILEPATH, wallet)
+    skale = SkaleManager(ENDPOINT, MANAGER_CONTRACTS, wallet)
 
     parser = argparse.ArgumentParser(
-        prog='FetchSchainsNodes',
-        description='Fetch schains by node info from mainnet'
+        prog='FetchSchainsNodes', description='Fetch schains by node info from mainnet'
     )
     parser.add_argument('-u', '--unique', action='store_true')
 
@@ -87,11 +83,7 @@ def main():
 
     schains = get_all_schains(skale)
 
-    schains_by_nodes = get_schains_by_nodes(
-        skale,
-        schains,
-        unique_nodes=args.unique
-    )
+    schains_by_nodes = get_schains_by_nodes(skale, schains, unique_nodes=args.unique)
     print(json.dumps(schains_by_nodes, indent=4))
 
 

--- a/skale-nodes/ansible/files/link_address.py
+++ b/skale-nodes/ansible/files/link_address.py
@@ -1,6 +1,6 @@
 import os
 
-from skale import Skale
+from skale import SkaleManager
 from skale.wallets import Web3Wallet
 from skale.utils.web3_utils import init_web3, to_checksum_address
 
@@ -9,27 +9,25 @@ BASE_DIR = os.getenv('BASE_DIR')
 ENDPOINT = os.getenv('ENDPOINT')
 ADDRESS = os.getenv('ADDRESS').strip()
 SIGNATURE = os.getenv('SIGNATURE').strip()
-ABI_FILEPATH = os.path.join(BASE_DIR, 'manager.json')
+MANAGER_CONTRACTS = os.getenv('MANAGER_CONTRACTS')
 ETH_PRIVATE_KEY = os.getenv('ETH_PRIVATE_KEY')
 
 
 def main():
     web3 = init_web3(ENDPOINT)
     wallet = Web3Wallet(ETH_PRIVATE_KEY, web3)
-    skale = Skale(ENDPOINT, ABI_FILEPATH, wallet)
+    skale = SkaleManager(ENDPOINT, MANAGER_CONTRACTS, wallet)
     print(ETH_PRIVATE_KEY)
     print(ADDRESS)
     print(SIGNATURE)
     checksum_address = to_checksum_address(ADDRESS)
     validator_address = skale.wallet.address
-    linked = skale.validator_service.get_linked_addresses_by_validator_address(
-        validator_address
-    )
+    linked = skale.validator_service.get_linked_addresses_by_validator_address(validator_address)
     if checksum_address not in linked:
         skale.validator_service.link_node_address(
             node_address=checksum_address,
             signature=SIGNATURE,
-            gas_price=skale.web3.eth.gas_price * 2
+            gas_price=skale.web3.eth.gas_price * 2,
         )
 
 

--- a/skale-nodes/ansible/files/prepare_base_wallet.py
+++ b/skale-nodes/ansible/files/prepare_base_wallet.py
@@ -20,7 +20,7 @@
 import logging
 import os
 
-from skale import Skale
+from skale import SkaleManager
 from skale.wallets import Web3Wallet
 from skale.utils.web3_utils import init_web3
 from skale.utils.helper import init_default_logger
@@ -31,29 +31,28 @@ init_default_logger()
 
 BASE_DIR = os.getenv('BASE_DIR')
 ENDPOINT = os.getenv('ENDPOINT')
-ABI_FILEPATH = os.path.join(BASE_DIR, 'manager.json')
+MANAGER_CONTRACTS = os.getenv('MANAGER_CONTRACTS')
 ETH_PRIVATE_KEY = os.getenv('ETH_PRIVATE_KEY')
 SKALE_AMOUNT = float(os.getenv('SKALE_AMOUNT'))
 ETH_AMOUNT = float(os.getenv('ETH_AMOUNT'))
 
 web3 = init_web3(ENDPOINT)
 wallet = Web3Wallet(ETH_PRIVATE_KEY, web3)
-skale = Skale(ENDPOINT, ABI_FILEPATH, wallet)
+skale = SkaleManager(ENDPOINT, MANAGER_CONTRACTS, wallet)
 
 
 def save_wallet_info(i, account):
-    filepath = os.path.join(BASE_DIR, f'wallet.txt')
+    filepath = os.path.join(BASE_DIR, 'wallet.txt')
     with open(filepath, 'w') as outfile:
         logger.info(f'Saving info to {filepath}')
-        outfile.write(account["private_key"])
+        outfile.write(account['private_key'])
 
 
 def prepare_wallet():
-    accounts = generate_accounts(skale, skale.wallet, 1,
-                                 SKALE_AMOUNT, ETH_AMOUNT, True)
+    accounts = generate_accounts(skale, skale.wallet, 1, SKALE_AMOUNT, ETH_AMOUNT, True)
     for i, account in enumerate(accounts):
         save_wallet_info(i, account)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     prepare_wallet()

--- a/skale-nodes/ansible/files/setup_validator.py
+++ b/skale-nodes/ansible/files/setup_validator.py
@@ -22,7 +22,7 @@ import os
 import random
 import string
 
-from skale import Skale
+from skale import SkaleManager
 from skale.wallets import Web3Wallet
 from skale.utils.web3_utils import init_web3
 from skale.utils.helper import init_default_logger
@@ -34,7 +34,7 @@ init_default_logger()
 
 BASE_DIR = os.getenv('BASE_DIR')
 ENDPOINT = os.getenv('ENDPOINT')
-ABI_FILEPATH = os.path.join(BASE_DIR, 'manager.json')
+MANAGER_CONTRACTS = os.getenv('MANAGER_CONTRACTS')
 ETH_PRIVATE_KEY = os.getenv('ETH_PRIVATE_KEY')
 ETH_AMOUNT = float(os.getenv('ETH_AMOUNT'))
 MIN_DELEGATION_AMOUNT = int(os.getenv('MIN_DELEGATION_AMOUNT'))
@@ -46,7 +46,7 @@ NODES_NUMBER = int(os.getenv('NODES_NUMBER'))
 
 web3 = init_web3(ENDPOINT)
 wallet = Web3Wallet(ETH_PRIVATE_KEY, web3)
-skale = Skale(ENDPOINT, ABI_FILEPATH, wallet)
+skale = SkaleManager(ENDPOINT, MANAGER_CONTRACTS, wallet)
 
 
 def create_base_account_for_validator(validator_web3) -> dict:
@@ -55,10 +55,9 @@ def create_base_account_for_validator(validator_web3) -> dict:
     return account_data
 
 
-def create_skale_for_validator(account_dict, validator_web3) -> Skale:
-    validator_skale = Skale(
-        ENDPOINT, ABI_FILEPATH,
-        Web3Wallet(account_dict['private_key'], validator_web3)
+def create_skale_for_validator(account_dict, validator_web3) -> SkaleManager:
+    validator_skale = SkaleManager(
+        ENDPOINT, MANAGER_CONTRACTS, Web3Wallet(account_dict['private_key'], validator_web3)
     )
     return validator_skale
 
@@ -66,15 +65,14 @@ def create_skale_for_validator(account_dict, validator_web3) -> Skale:
 def create_validator(name):
     validator_web3 = init_web3(ENDPOINT)
     validator_base_account = create_base_account_for_validator(validator_web3)
-    validator_skale = create_skale_for_validator(validator_base_account,
-                                                 validator_web3)
+    validator_skale = create_skale_for_validator(validator_base_account, validator_web3)
 
     tx_res = validator_skale.validator_service.register_validator(
         name=name,
         description=f'Validator for node {name}',
         fee_rate=COMMISSION_RATE,
         min_delegation_amount=MIN_DELEGATION_AMOUNT,
-        wait_for=True
+        wait_for=True,
     )
     tx_res.raise_for_status()
 
@@ -85,8 +83,7 @@ def create_validator(name):
 
 def whitelist_validator(validator_id):
     if not skale.validator_service._is_authorized_validator(validator_id):
-        tx_res = skale.validator_service._enable_validator(validator_id,
-                                                           wait_for=True)
+        tx_res = skale.validator_service._enable_validator(validator_id, wait_for=True)
         tx_res.raise_for_status()
 
 
@@ -99,10 +96,7 @@ def setup_validator():
     vid, pkey = create_validator(name)
 
     whitelist_validator(vid)
-    skale.constants_holder._set_msr(
-        new_msr=0,
-        wait_for=True
-    )
+    skale.constants_holder._set_msr(new_msr=0, wait_for=True)
     with open(BASE_KEY_FILEPATH, 'w') as pkey_file:
         pkey_file.write(pkey)
     with open(VALIDATOR_ID_FILEPATH, 'w') as vid_file:
@@ -114,5 +108,5 @@ def main():
     setup_validator()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/skale-nodes/ansible/files/transfer_funds.py
+++ b/skale-nodes/ansible/files/transfer_funds.py
@@ -20,7 +20,7 @@
 import os
 import logging
 
-from skale import Skale
+from skale import SkaleManager
 from skale.wallets import Web3Wallet
 from skale.utils.web3_utils import init_web3
 from skale.utils.helper import init_default_logger
@@ -30,7 +30,7 @@ from skale.utils.web3_utils import to_checksum_address
 
 BASE_DIR = os.getenv('BASE_DIR')
 ENDPOINT = os.getenv('ENDPOINT')
-ABI_FILEPATH = os.path.join(BASE_DIR, 'manager.json')
+MANAGER_CONTRACTS = os.getenv('MANAGER_CONTRACTS')
 ETH_PRIVATE_KEY = os.getenv('ETH_PRIVATE_KEY')
 ADDRESS = os.getenv('ADDRESS')
 AMOUNT = float(os.getenv('AMOUNT'))
@@ -42,7 +42,7 @@ init_default_logger()
 def init_web3_skale():
     web3 = init_web3(ENDPOINT)
     wallet = Web3Wallet(ETH_PRIVATE_KEY, web3)
-    return Skale(ENDPOINT, ABI_FILEPATH, wallet)
+    return SkaleManager(ENDPOINT, MANAGER_CONTRACTS, wallet)
 
 
 def main():
@@ -51,5 +51,5 @@ def main():
     send_eth(skale.web3, skale.wallet, address, AMOUNT)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/skale-nodes/ansible/main.yaml
+++ b/skale-nodes/ansible/main.yaml
@@ -1,6 +1,6 @@
-- import_playbook: base.yaml
-- import_playbook: geth.yaml
 - import_playbook: deploy_contracts.yaml
+- import_playbook: base.yaml
+# - import_playbook: geth.yaml
 - import_playbook: sgx_sim.yaml
 - import_playbook: setup.yaml
 - import_playbook: validator.yaml

--- a/skale-nodes/ansible/main.yaml
+++ b/skale-nodes/ansible/main.yaml
@@ -1,6 +1,7 @@
-# - import_playbook: deploy_contracts.yaml
 - import_playbook: base.yaml
-- import_playbook: sgx.yaml
+- import_playbook: geth.yaml
+- import_playbook: deploy_contracts.yaml
+- import_playbook: sgx_sim.yaml
 - import_playbook: setup.yaml
 - import_playbook: validator.yaml
 - import_playbook: signature.yaml

--- a/skale-nodes/ansible/requirements.txt
+++ b/skale-nodes/ansible/requirements.txt
@@ -1,3 +1,3 @@
-ansible==4.2.0
+ansible==11.3.0
 skale.py==7.0dev2
 boto3==1.17.34

--- a/skale-nodes/ansible/requirements.txt
+++ b/skale-nodes/ansible/requirements.txt
@@ -1,4 +1,3 @@
 ansible==4.2.0
-skale.py==5.1dev7
+skale.py==7.0dev2
 boto3==1.17.34
-eth-account==0.5.3

--- a/skale-nodes/ansible/restore_schain.yaml
+++ b/skale-nodes/ansible/restore_schain.yaml
@@ -8,6 +8,7 @@
       environment:
         ETH_PRIVATE_KEY: "{{ eth_private_key }}"
         ENDPOINT: "{{ endpoint }}"
+        MANAGER_CONTRACTS: "{{ manager_contracts }}"
         BASE_DIR: "files"
       args:
         executable: python3

--- a/skale-nodes/ansible/roles/cleanup_artifacts/tasks/main.yaml
+++ b/skale-nodes/ansible/roles/cleanup_artifacts/tasks/main.yaml
@@ -4,15 +4,13 @@
     path: "{{ playbook_dir}}/files/node-info/"
   tags: node_info_cleanup
 
-
 - name: Cleanup group_vars/all from contracts links
   lineinfile:
     state: absent
     regexp: "{{ item }}"
     path: "{{ playbook_dir }}/group_vars/all"
-  loop: ["^sm_url", "^ima_url"]
+  loop: ["^sm_address", "^ima_address"]
   tags: group_vars_cleanup
-
 
 - name: Find all abis
   find:
@@ -20,19 +18,16 @@
     patterns: ["*.json"]
   register: abi_files
 
-
 - name: Cleanup contract abis
   file:
     state: absent
     path: "{{ item.path }}"
   loop: "{{ abi_files.files }}"
 
-
 - name: Cleanup manager manifests
   file:
     state: absent
     path: "{{ playbook_dir }}/../../helper-scripts/contracts_data/openzeppelin"
-
 
 - name: Cleanup ima manifests
   file:

--- a/skale-nodes/ansible/roles/cleanup_contracts/tasks/main.yaml
+++ b/skale-nodes/ansible/roles/cleanup_contracts/tasks/main.yaml
@@ -5,6 +5,7 @@
     BASE_DIR: "files"
     ETH_PRIVATE_KEY: "{{ eth_private_key }}"
     ENDPOINT: "{{ endpoint }}"
+    MANAGER_CONTRACTS: "{{ manager_contracts }}"
   args:
     executable: python3
   tags:

--- a/skale-nodes/ansible/roles/cleanup_nodes/tasks/containers.yaml
+++ b/skale-nodes/ansible/roles/cleanup_nodes/tasks/containers.yaml
@@ -1,5 +1,5 @@
 - name: Get monitoring container ids
-  command: 'docker ps -a -q --filter="name=monitoring_"'
+  command: 'docker ps -a -q --filter="name=monitor_"'
   become: true
   register: containers_output
 

--- a/skale-nodes/ansible/roles/config/tasks/main.yaml
+++ b/skale-nodes/ansible/roles/config/tasks/main.yaml
@@ -1,10 +1,10 @@
-  # - name: Get block device from lvm-block-device file created by terraform
-  #   shell: cat "{{ base_path }}/lvm-block-device"
-  #   register: block_device
+# - name: Get block device from lvm-block-device file created by terraform
+#   shell: cat "{{ base_path }}/lvm-block-device"
+#   register: block_device
 
 - name: Set SM download URL
   set_fact:
-    manager_contracts: "{{ sm_url }}"
+    manager_contracts: "{{ sm_address }}"
   when: manager_contracts is undefined
   tags: contracts
 
@@ -16,7 +16,7 @@
 
 - name: Set IMA download URL
   set_fact:
-    ima_contracts: "{{ ima_url }}"
+    ima_contracts: "{{ ima_address }}"
   when: ima_contracts is undefined
   tags: contracts
 
@@ -46,8 +46,8 @@
       IMA_ENDPOINT="{{ ima_endpoint }}"
       CONTAINER_CONFIGS_STREAM="{{ container_configs_stream }}"
       FILEBEAT_HOST="{{ filebeat_host }}"
-      MANAGER_CONTRACTS_ABI_URL="{{ manager_contracts }}"
-      IMA_CONTRACTS_ABI_URL="{{ ima_contracts }}"
+      MANAGER_CONTRACTS="{{ manager_contracts }}"
+      IMA_CONTRACTS="{{ ima_contracts }}"
       CONTAINER_CONFIGS_DIR="{{ container_configs_dir }}"
       DOCKER_LVMPY_STREAM="{{ docker_lvmpy_stream }}"
       DISK_MOUNTPOINT="{{ block_device }}"
@@ -74,8 +74,8 @@
       DOCKER_LVMPY_STREAM="{{ docker_lvmpy_stream }}"
       ENV_TYPE="{{ env_type }}"
       SCHAIN_NAME="{{ schain_name }}"
-      MANAGER_CONTRACTS_ABI_URL={{ manager_contracts }}
-      IMA_CONTRACTS_ABI_URL={{ ima_contracts }}
+      MANAGER_CONTRACTS={{ manager_contracts }}
+      IMA_CONTRACTS={{ ima_contracts }}
       DISK_MOUNTPOINT={{ block_device }}
       INFLUX_URL="{{ influx_url }}"
       TELEGRAF="{{ telegraf }}"

--- a/skale-nodes/ansible/roles/config/tasks/main.yaml
+++ b/skale-nodes/ansible/roles/config/tasks/main.yaml
@@ -2,36 +2,28 @@
 #   shell: cat "{{ base_path }}/lvm-block-device"
 #   register: block_device
 
-- name: Set SM download URL
+- name: Set Skale Manager contract address
   set_fact:
     manager_contracts: "{{ sm_address }}"
   when: manager_contracts is undefined
   tags: contracts
 
-- name: Crash if no SM ABIs URL provided
+- name: Crash if no Skale Manager contract address provided
   fail:
     msg: manager_contracts is undefined
   when: manager_contracts is undefined
   tags: contracts
 
-- name: Set IMA download URL
+- name: Set IMA contract address
   set_fact:
     ima_contracts: "{{ ima_address }}"
   when: ima_contracts is undefined
   tags: contracts
 
-- name: Crash if no IMA ABIs URL provided
+- name: Crash if no IMA contract address provided
   fail:
     msg: ima_contracts is undefined
   when: ima_contracts is undefined
-  tags: contracts
-
-- name: Download contracts
-  get_url:
-    url: "{{ manager_contracts }}"
-    dest: "{{ base_path }}/manager.json"
-    mode: 0644
-    force: true
   tags: contracts
 
 - name: Set sgx url

--- a/skale-nodes/ansible/roles/deploy_contracts/tasks/ima.yaml
+++ b/skale-nodes/ansible/roles/deploy_contracts/tasks/ima.yaml
@@ -9,36 +9,9 @@
   tags:
     - deploy_ima
 
-- name: Generate random string
-  set_fact:
-    random_str: "{{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=15') }}"
-  tags:
-    - upload_ima
-
-- name: Upload IMA ABI to S3
-  aws_s3:
-    aws_access_key: "{{ aws_key }}"
-    aws_secret_key: "{{ aws_secret }}"
-    bucket: "skale-abis"
-    src: "{{ playbook_dir }}/../../helper-scripts/contracts_data/ima.json"
-    object: 'ima-abi-{{ ima_tag }}-{{ random_str }}.json'
-    region: 'eu-central-1'
-    mode: put
-    permission: "public-read"
-  tags:
-    - upload_ima
-  register: url_output
-
-- name: Format download URL
-  shell:  echo "{{ url_output.url }}" | cut -f1 -d"?"
-  register: ima_url
-  tags:
-    - upload_ima
-
-- name: Show ABIs download URL
-  debug:
-   msg: >-
-      ABIs download URL: {{ ima_url.stdout }}
+- name: Get SM Contract Address
+  shell: "jq -r '.message_proxy_mainnet_address' {{ playbook_dir }}/../../helper-scripts/contracts_data/ima.json"
+  register: ima_address
   tags:
     - upload_ima
 
@@ -46,8 +19,8 @@
   lineinfile:
     path: "{{ playbook_dir }}/group_vars/all"
     insertafter: EOF
-    regexp: '^ima_url:'
-    line: "ima_url: {{ ima_url.stdout }}"
+    regexp: "^ima_address:"
+    line: "ima_address: {{ ima_address.stdout }}"
     state: present
   tags:
     - upload_ima

--- a/skale-nodes/ansible/roles/deploy_contracts/tasks/manager.yaml
+++ b/skale-nodes/ansible/roles/deploy_contracts/tasks/manager.yaml
@@ -9,47 +9,11 @@
     NETWORK: "custom"
   tags: deploy_sm
 
-
-- name: Save SM URL to group vars
+- name: Copy SM ABI
   copy:
     src: "{{ playbook_dir }}/../../helper-scripts/contracts_data/manager.json"
     dest: "{{ playbook_dir }}/../../helper-scripts/contracts_data/skaleManagerComponents.json"
   tags: upload_sm
-
-
-- name: Generate random string
-  set_fact:
-    random_str: "{{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=15') }}"
-  tags: upload_sm
-
-
-- name: Upload SM ABI to S3
-  aws_s3:
-    aws_access_key: "{{ aws_key }}"
-    aws_secret_key: "{{ aws_secret }}"
-    bucket: "skale-abis"
-    src: "{{ playbook_dir }}/../../helper-scripts/contracts_data/manager.json"
-    object: "skale-manager-abi-{{ manager_tag }}-{{ random_str }}.json"
-    region: "eu-central-1"
-    mode: put
-    permission: "public-read"
-  tags: upload_sm
-  register: url_output
-
-
-- name: Format download URL
-  shell:  echo "{{ url_output.url }}" | cut -f1 -d"?"
-  register: sm_url
-  tags: upload_sm
-
-
-- name: Show ABIs download URL
-  debug:
-   msg: >-
-      ABIs download URL: {{ sm_url.stdout }}
-  tags:
-    - upload_sm
-
 
 - name: Ensure group vars all
   file:
@@ -57,12 +21,16 @@
     path: "{{ playbook_dir }}/group_vars/all"
   tags: upload_sm
 
+- name: Get SM Contract Address
+  shell: "jq -r '.skale_manager_address' {{ playbook_dir }}/../../helper-scripts/contracts_data/manager.json"
+  register: sm_address
+  tags: upload_sm
 
 - name: Save SM URL to group vars
   lineinfile:
     path: "{{ playbook_dir }}/group_vars/all"
     insertafter: EOF
-    regexp: '^sm_url:'
-    line: "sm_url: {{ sm_url.stdout }}"
+    regexp: "^sm_address:"
+    line: "sm_address: {{ sm_address.stdout }}"
     state: present
   tags: upload_sm

--- a/skale-nodes/ansible/roles/deploy_contracts/tasks/manager.yaml
+++ b/skale-nodes/ansible/roles/deploy_contracts/tasks/manager.yaml
@@ -7,6 +7,7 @@
     ENDPOINT: "{{ endpoint }}"
     GAS_PRICE: "{{ deploy_gas_price }}"
     NETWORK: "custom"
+    ETHERSCAN: "{{ etherscan }}"
   tags: deploy_sm
 
 - name: Copy SM ABI

--- a/skale-nodes/ansible/roles/link_addresses/tasks/link_addresses.yaml
+++ b/skale-nodes/ansible/roles/link_addresses/tasks/link_addresses.yaml
@@ -11,6 +11,7 @@
     ADDRESS: "{{ lookup('file', '{{ item }}').split()[0].strip() }}"
     SIGNATURE: "{{ lookup('file', '{{ item }}').split()[1].strip() }}"
     ENDPOINT: "{{ endpoint }}"
+    MANAGER_CONTRACTS: "{{ manager_contracts }}"
     BASE_DIR: "files"
   args:
     executable: python3

--- a/skale-nodes/ansible/roles/link_addresses/tasks/transfer_funds.yaml
+++ b/skale-nodes/ansible/roles/link_addresses/tasks/transfer_funds.yaml
@@ -5,6 +5,7 @@
     ETH_PRIVATE_KEY: "{{ eth_private_key }}"
     ADDRESS: "{{ lookup('file', '{{ item }}').split()[0].strip() }}"
     ENDPOINT: "{{ endpoint }}"
+    MANAGER_CONTRACTS: "{{ manager_contracts }}"
     BASE_DIR: "files"
     AMOUNT: 0.2
   args:

--- a/skale-nodes/ansible/roles/sync/templates/docker-compose-sync.yml.j2
+++ b/skale-nodes/ansible/roles/sync/templates/docker-compose-sync.yml.j2
@@ -31,6 +31,8 @@ services:
       ENV_TYPE: ${ENV_TYPE}
       SCHAIN_NAME: ${SCHAIN_NAME}
       SYNC_NODE: "True"
+      MANAGER_CONTRACTS: ${MANAGER_CONTRACTS}
+      IMA_CONTRACTS: ${IMA_CONTRACTS}
     command: "python3 sync_node.py"
     volumes:
       - /var/run/skale:/var/run/skale

--- a/skale-nodes/ansible/roles/sync/templates/docker-compose.yml.j2
+++ b/skale-nodes/ansible/roles/sync/templates/docker-compose.yml.j2
@@ -63,6 +63,8 @@ services:
       ALLOWED_TS_DIFF: 10000
       TELEGRAF: "${TELEGRAF}"
       INFLUX_URL: "${INFLUX_URL}"
+      MANAGER_CONTRACTS: ${MANAGER_CONTRACTS}
+      IMA_CONTRACTS: ${IMA_CONTRACTS}
     command: "python3 admin.py"
     volumes:
       - /var/run/skale:/var/run/skale
@@ -112,6 +114,8 @@ services:
       ENV_TYPE: ${ENV_TYPE}
       DEFAULT_TIMEOUT: ${DEFAULT_TIMEOUT}
       ALLOWED_TS_DIFF: 10000
+      MANAGER_CONTRACTS: ${MANAGER_CONTRACTS}
+      IMA_CONTRACTS: ${IMA_CONTRACTS}
     command: "gunicorn app:app -c gunicorn.conf.py"
     volumes:
       - /var/run/skale:/var/run/skale
@@ -169,6 +173,8 @@ services:
       DEFAULT_GAS_LIMIT: ${DEFAULT_GAS_LIMIT}
       DEFAULT_GAS_PRICE_WEI: ${DEFAULT_GAS_PRICE_WEI}
       ALLOWED_TS_DIFF: 10000
+      MANAGER_CONTRACTS: ${MANAGER_CONTRACTS}
+      IMA_CONTRACTS: ${IMA_CONTRACTS}
     volumes:
       - ${SKALE_DIR}:/skale_vol
       - ${SKALE_DIR}/node_data:/skale_node_data

--- a/skale-nodes/ansible/roles/update/tasks/skale_update.yaml
+++ b/skale-nodes/ansible/roles/update/tasks/skale_update.yaml
@@ -1,6 +1,6 @@
 - name: Run skale node update
   shell:
-    cmd: "skale node update {{ base_path }}/init-env --yes --pull-config all"
+    cmd: "skale node update {{ base_path }}/init-env --yes --pull-config all --unsafe"
   environment:
     LANG: en_US.utf-8
     LC_ALL: en_US.utf-8
@@ -10,7 +10,7 @@
 
 - name: Run skale sync node update
   shell:
-    cmd: "skale sync-node update {{ base_path }}/init-env --yes"
+    cmd: "skale sync-node update {{ base_path }}/init-env --yes --unsafe"
   environment:
     LANG: en_US.utf-8
     LC_ALL: en_US.utf-8

--- a/skale-nodes/ansible/roles/validators/tasks/generate.yaml
+++ b/skale-nodes/ansible/roles/validators/tasks/generate.yaml
@@ -1,19 +1,12 @@
-- name: Set SM download URL
+- name: Set Skale Manager contract address
   set_fact:
-    manager_contracts: "{{ sm_url }}"
+    manager_contracts: "{{ sm_address }}"
   when: manager_contracts is undefined
 
-- name: Crash if no SM ABIs URL provided
-  fail: 
+- name: Crash if no Skale Manager contract address provided
+  fail:
     msg: manager_contracts is undefined
   when: manager_contracts is undefined
-
-- name: Download contracts to the local machine
-  get_url:
-      url: "{{ manager_contracts }}"
-      dest: "files/manager.json"
-      mode: 0644
-      validate_certs: false
 
 - name: Set hosts
   set_fact: hosts="{{ hosts|default([]) + [ item.value['ansible_host'] ] }}"

--- a/skale-nodes/ansible/roles/validators/tasks/generate.yaml
+++ b/skale-nodes/ansible/roles/validators/tasks/generate.yaml
@@ -21,6 +21,7 @@
     ETH_PRIVATE_KEY: "{{ eth_private_key }}"
     ENDPOINT: "{{ endpoint }}"
     MIN_DELEGATION_AMOUNT: "0"
+    MANAGER_CONTRACTS: "{{ manager_contracts }}"
     COMMISSION_RATE: "1"
     NODES_NUMBER: "{{ hosts|length }}"
   args:


### PR DESCRIPTION
This PR integrates Skale contracts by replacing the usage of the previous Skale interface with the new SkaleManager and updating related configuration and cleanup tasks. Key changes include:

- Refactoring Ansible roles and playbooks to use MANAGER_CONTRACTS and retrieve contract addresses via jq.
- Updating Python scripts to import and use SkaleManager instead of Skale.
- Modifying cleanup and backup tasks to align with the new contracts integration.