### PR TITLE
Add chain and node deleting playbooks

### DIFF
--- a/skale-nodes/ansible/cleanup_contracts.yaml
+++ b/skale-nodes/ansible/cleanup_contracts.yaml
@@ -1,4 +1,4 @@
-- name: Cleanup contracts from schains and nodes
+- name: Cleanup contracts from chains and nodes
   hosts: 127.0.0.1
   connection: local
   roles:

--- a/skale-nodes/ansible/cleanup_contracts.yaml
+++ b/skale-nodes/ansible/cleanup_contracts.yaml
@@ -1,0 +1,6 @@
+- name: Cleanup contracts from schains and nodes
+  hosts: 127.0.0.1
+  connection: local
+  roles:
+    - role: cleanup_contracts
+      tags: cleanup_contracts

--- a/skale-nodes/ansible/delete_chain.yaml
+++ b/skale-nodes/ansible/delete_chain.yaml
@@ -1,0 +1,7 @@
+- name: Delete chain on SKALE or Mirage nodes
+  hosts: 127.0.0.1
+  connection: local
+  roles:
+    - role: delete_chain
+      tags:
+        - delete_chain

--- a/skale-nodes/ansible/files/cleanup_contracts.py
+++ b/skale-nodes/ansible/files/cleanup_contracts.py
@@ -1,46 +1,71 @@
 import logging
 import os
+import sys
+from eth_typing import HexStr
 
 from skale import SkaleManager
 from skale.wallets import Web3Wallet
 from skale.utils.web3_utils import init_web3
 from skale.utils.helper import init_default_logger
+from skale.utils.contracts_provision.main import cleanup_nodes
 
 logger = logging.getLogger(__name__)
 init_default_logger()
 
-BASE_DIR = os.getenv('BASE_DIR')
 ENDPOINT = os.getenv('ENDPOINT')
 MANAGER_CONTRACTS = os.getenv('MANAGER_CONTRACTS')
 ETH_PRIVATE_KEY = os.getenv('ETH_PRIVATE_KEY')
 
-web3 = init_web3(ENDPOINT)
-wallet = Web3Wallet(ETH_PRIVATE_KEY, web3)
-skale = SkaleManager(ENDPOINT, MANAGER_CONTRACTS, wallet)
+
+def init_skale_manager(
+    endpoint: str, alias_or_address: str, eth_private_key: HexStr
+) -> SkaleManager:
+    web3 = init_web3(endpoint)
+    wallet = Web3Wallet(eth_private_key, web3)
+    return SkaleManager(endpoint, alias_or_address, wallet)
 
 
-def remove_active_nodes():
-    for node_id in skale.nodes.get_active_node_ids():
-        skale.manager.node_exit(node_id, wait_for=True)
+def remove_active_nodes(skale):
+    logger.info('Removing all active nodes...')
+    cleanup_nodes(skale)
+    logger.info('Finished removing active nodes')
 
 
 def get_all_schains_names(skale):
     schains_ids = skale.schains_internal.get_all_schains_ids()
-    print(schains_ids)
-    names = [skale.schains.get(sid).get('name') for sid in schains_ids]
+    logger.info(f'Found chain IDs: {schains_ids}')
+    names = [skale.schains.get(sid).name for sid in schains_ids]
     return names
 
 
-def remove_all_schains():
+def remove_all_schains(skale):
+    logger.info('Removing all chains...')
     schain_names = get_all_schains_names(skale)
+    if not schain_names:
+        logger.info('No chains found to remove')
+        return
     for name in schain_names:
+        logger.info(f'Deleting chain: {name}')
         skale.manager.delete_schain(name, wait_for=True)
+    logger.info('Finished removing chains')
 
 
-def cleanup():
-    remove_all_schains()
-    remove_active_nodes()
+def cleanup(skale):
+    remove_all_schains(skale)
+    remove_active_nodes(skale)
 
 
 if __name__ == '__main__':
-    cleanup()
+    skale = init_skale_manager(ENDPOINT, MANAGER_CONTRACTS, HexStr(ETH_PRIVATE_KEY))
+    if len(sys.argv) > 1:
+        action = sys.argv[1]
+        if action == 'remove_schains':
+            remove_all_schains(skale)
+        elif action == 'remove_nodes':
+            remove_active_nodes(skale)
+        else:
+            logger.error(f'Unknown action: {action}. Please use "remove_schains" or "remove_nodes"')
+            sys.exit(1)
+    else:
+        logger.info('No action specified, running full cleanup')
+        cleanup(skale)

--- a/skale-nodes/ansible/files/cleanup_contracts.py
+++ b/skale-nodes/ansible/files/cleanup_contracts.py
@@ -59,12 +59,12 @@ if __name__ == '__main__':
     skale = init_skale_manager(ENDPOINT, MANAGER_CONTRACTS, HexStr(ETH_PRIVATE_KEY))
     if len(sys.argv) > 1:
         action = sys.argv[1]
-        if action == 'remove_schains':
+        if action == 'remove_chains':
             remove_all_schains(skale)
         elif action == 'remove_nodes':
             remove_active_nodes(skale)
         else:
-            logger.error(f'Unknown action: {action}. Please use "remove_schains" or "remove_nodes"')
+            logger.error(f'Unknown action: {action}. Please use "remove_chains" or "remove_nodes"')
             sys.exit(1)
     else:
         logger.info('No action specified, running full cleanup')

--- a/skale-nodes/ansible/files/create_chain.py
+++ b/skale-nodes/ansible/files/create_chain.py
@@ -1,10 +1,10 @@
 #   -*- coding: utf-8 -*-
 #
-#   This file is part of SKALE.py
+#   This file is part of node-provisoning
 #
 #   Copyright (C) 2025-Present SKALE Labs
 #
-#   SKALE.py is free software: you can redistribute it and/or modify
+#   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU Affero General Public License as published by
 #   the Free Software Foundation, either version 3 of the License, or
 #   (at your option) any later version.
@@ -15,7 +15,7 @@
 #   GNU Affero General Public License for more details.
 #
 #   You should have received a copy of the GNU Affero General Public License
-#   along with SKALE.py.  If not, see <https://www.gnu.org/licenses/>.
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import os
 from eth_typing import HexStr

--- a/skale-nodes/ansible/files/delete_chain.py
+++ b/skale-nodes/ansible/files/delete_chain.py
@@ -1,0 +1,43 @@
+#   -*- coding: utf-8 -*-
+#
+#   This file is part of SKALE.py
+#
+#   Copyright (C) 2025-Present SKALE Labs
+#
+#   SKALE.py is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   SKALE.py is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with SKALE.py.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+from eth_typing import HexStr
+from skale import SkaleManager
+from skale.utils.web3_utils import init_web3
+from skale.wallets import Web3Wallet
+
+CHAIN_NAME = os.environ['CHAIN_NAME']
+ENDPOINT = os.environ['ENDPOINT']
+ETH_PRIVATE_KEY = os.environ['ETH_PRIVATE_KEY']
+MANAGER_CONTRACTS = os.environ['MANAGER_CONTRACTS']
+
+
+def init_skale_manager(
+    endpoint: str, alias_or_address: str, eth_private_key: HexStr
+) -> SkaleManager:
+    web3 = init_web3(endpoint)
+    wallet = Web3Wallet(eth_private_key, web3)
+    return SkaleManager(endpoint, alias_or_address, wallet)
+
+
+if __name__ == '__main__':
+    skale = init_skale_manager(ENDPOINT, MANAGER_CONTRACTS, HexStr(ETH_PRIVATE_KEY))
+    skale.manager.delete_schain_by_root(CHAIN_NAME, wait_for=True)
+    print(f'Schain {CHAIN_NAME} is deleted!')

--- a/skale-nodes/ansible/files/delete_chain.py
+++ b/skale-nodes/ansible/files/delete_chain.py
@@ -1,10 +1,10 @@
 #   -*- coding: utf-8 -*-
 #
-#   This file is part of SKALE.py
+#   This file is part of node-provisoning
 #
 #   Copyright (C) 2025-Present SKALE Labs
 #
-#   SKALE.py is free software: you can redistribute it and/or modify
+#   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU Affero General Public License as published by
 #   the Free Software Foundation, either version 3 of the License, or
 #   (at your option) any later version.
@@ -15,7 +15,7 @@
 #   GNU Affero General Public License for more details.
 #
 #   You should have received a copy of the GNU Affero General Public License
-#   along with SKALE.py.  If not, see <https://www.gnu.org/licenses/>.
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import os
 from eth_typing import HexStr

--- a/skale-nodes/ansible/roles/cleanup_artifacts/tasks/main.yaml
+++ b/skale-nodes/ansible/roles/cleanup_artifacts/tasks/main.yaml
@@ -10,29 +10,36 @@
     regexp: "{{ item }}"
     path: "{{ playbook_dir }}/group_vars/all"
   loop: ["^manager_contracts", "^ima_contracts"]
-  tags: group_vars_cleanup
+  tags:
+    - group_vars_cleanup
+    - contract_data_cleanup
+
 
 - name: Find all abis
   find:
     paths: ["{{ playbook_dir }}/../../helper-scripts/contracts_data"]
     patterns: ["*.json"]
   register: abi_files
+  tags: contract_data_cleanup
 
 - name: Cleanup contract abis
   file:
     state: absent
     path: "{{ item.path }}"
   loop: "{{ abi_files.files }}"
+  tags: contract_data_cleanup
 
 - name: Cleanup manager manifests
   file:
     state: absent
     path: "{{ playbook_dir }}/../../helper-scripts/contracts_data/openzeppelin"
+  tags: contract_data_cleanup
 
 - name: Cleanup ima manifests
   file:
     state: absent
     path: "{{ playbook_dir }}/../../helper-scripts/contracts_data/ima-openzeppelin"
+  tags: contract_data_cleanup
 
 - name: Remove validator-id and validator-key files
   file:
@@ -40,3 +47,4 @@
     state: absent
   with_fileglob:
     - "{{ playbook_dir}}/files/validator-*.txt"
+  tags: validator_data_cleanup

--- a/skale-nodes/ansible/roles/cleanup_contracts/tasks/main.yaml
+++ b/skale-nodes/ansible/roles/cleanup_contracts/tasks/main.yaml
@@ -1,6 +1,6 @@
-- name: Cleanup contracts - remove all s-chains
+- name: Cleanup contracts - remove all chains
   script:
-    cmd: cleanup_contracts.py remove_schains
+    cmd: cleanup_contracts.py remove_chains
   run_once: yes
   environment:
     BASE_DIR: "files"
@@ -10,7 +10,7 @@
   args:
     executable: python3
   tags:
-    - cleanup_schains
+    - cleanup_chains
 
 - name: Cleanup contracts - remove all active nodes
   ansible.builtin.script:

--- a/skale-nodes/ansible/roles/cleanup_contracts/tasks/main.yaml
+++ b/skale-nodes/ansible/roles/cleanup_contracts/tasks/main.yaml
@@ -1,5 +1,6 @@
-- name: Cleanup contracts
-  script: cleanup_contracts.py
+- name: Cleanup contracts - remove all s-chains
+  script:
+    cmd: cleanup_contracts.py remove_schains
   run_once: yes
   environment:
     BASE_DIR: "files"
@@ -9,5 +10,18 @@
   args:
     executable: python3
   tags:
-    - cleanup
-    - cleanup_contracts
+    - cleanup_schains
+
+- name: Cleanup contracts - remove all active nodes
+  ansible.builtin.script:
+    cmd: cleanup_contracts.py remove_nodes
+  run_once: yes
+  environment:
+    BASE_DIR: "files"
+    ETH_PRIVATE_KEY: "{{ eth_private_key }}"
+    ENDPOINT: "{{ endpoint }}"
+    MANAGER_CONTRACTS: "{{ manager_contracts }}"
+  args:
+    executable: python3
+  tags:
+    - cleanup_nodes

--- a/skale-nodes/ansible/roles/config/tasks/main.yaml
+++ b/skale-nodes/ansible/roles/config/tasks/main.yaml
@@ -36,7 +36,7 @@
     env_options: |
       MIRAGE_CONTRACTS="{{ mirage_contracts }}"
       CONTAINER_CONFIGS_STREAM="{{ container_configs_stream }}"
-      BOOT_ENDPOINT="{{ boot_endpoint }}"
+      BOOT_ENDPOINT="{{ endpoint }}"
       CONTAINER_CONFIGS_DIR="{{ container_configs_dir if (build_type | default('')) == 'source' else ''}}"
       SGX_SERVER_URL="{{ sgx_url }}"
       DISK_MOUNTPOINT="{{ block_device }}"

--- a/skale-nodes/ansible/roles/config/tasks/main.yaml
+++ b/skale-nodes/ansible/roles/config/tasks/main.yaml
@@ -36,7 +36,7 @@
     env_options: |
       MIRAGE_CONTRACTS="{{ mirage_contracts }}"
       CONTAINER_CONFIGS_STREAM="{{ container_configs_stream }}"
-      BOOT_ENDPOINT="{{ endpoint }}"
+      BOOT_ENDPOINT="{{ boot_endpoint }}"
       CONTAINER_CONFIGS_DIR="{{ container_configs_dir if (build_type | default('')) == 'source' else ''}}"
       SGX_SERVER_URL="{{ sgx_url }}"
       DISK_MOUNTPOINT="{{ block_device }}"

--- a/skale-nodes/ansible/roles/delete_chain/tasks/main.yaml
+++ b/skale-nodes/ansible/roles/delete_chain/tasks/main.yaml
@@ -1,0 +1,11 @@
+- name: Execute delete_chain script
+  script: delete_chain.py
+  environment:
+    BASE_DIR: "files"
+    ETH_PRIVATE_KEY: "{{ eth_private_key }}"
+    ENDPOINT: "{{ endpoint }}"
+    MANAGER_CONTRACTS: "{{ manager_contracts }}"
+    CHAIN_NAME: "{{ chain_name }}"
+  args:
+    executable: python3
+  tags: delete_chain

--- a/skale-nodes/ansible/roles/deploy_mirage/tasks/main.yaml
+++ b/skale-nodes/ansible/roles/deploy_mirage/tasks/main.yaml
@@ -5,7 +5,7 @@
     MIRAGE_TAG: "{{ mirage_tag }}"
     ETH_PRIVATE_KEY: "{{ eth_private_key }}"
     MAINNET_ENDPOINT: "{{ endpoint }}"
-    ENDPOINT: "{{ mirage_endpoint }}"
+    ENDPOINT: "{{ boot_endpoint }}"
     CHAIN_NAME: "{{ chain_name }}"
     TARGET: "{{ manager_contracts }}"
   tags: deploy_mirage


### PR DESCRIPTION
This pull request introduces new Ansible playbooks and scripts to streamline SKALE node and chain management. Key changes include the addition of dedicated playbooks for cleaning up contracts and deleting chains, refactoring the cleanup logic for better modularity, and implementing environment-specific configurations for SKALE operations.

### New Playbooks for Node and Chain Management:
* [`skale-nodes/ansible/cleanup_contracts.yaml`](diffhunk://#diff-31fe65f90fa0160f155c3f371d2f1e1fcd02f36671d5a79ff1f6cfadb127c7b9R1-R6): Added a playbook to clean up contracts from chains and nodes.
* [`skale-nodes/ansible/delete_chain.yaml`](diffhunk://#diff-66dc0a9300e3035350b54f6186cc42cd14799a04aae4d86e75bd2e7c2d1a8262R1-R7): Added a playbook to delete chains on SKALE or Mirage nodes.

### Refactored Cleanup Logic:
* [`skale-nodes/ansible/files/cleanup_contracts.py`](diffhunk://#diff-be6d211a4d32d9bef931dff717bcfb89b9be40d79c915c4aeeae8005e7ef6bc2R3-R71): Refactored cleanup logic to modularize SKALE manager initialization and separate chain and node removal actions. Added logging for better traceability.
* [`skale-nodes/ansible/roles/cleanup_contracts/tasks/main.yaml`](diffhunk://#diff-4b526f89a14fba657d951052a642d5c603809ad2bdf9050adeff7d692a15f92aL1-R3): Updated tasks to run specific cleanup actions (`remove_chains` and `remove_nodes`) separately, with improved environment variable handling.

### New Script for Chain Deletion:
* [`skale-nodes/ansible/files/delete_chain.py`](diffhunk://#diff-9d6f67ad8830ed720693356790ce308c4e4a0554c7ffea5bed685e8f1617ed78R1-R43): Introduced a script to delete chains using SKALE manager, with environment-specific configurations for chain name and SKALE credentials.
* [`skale-nodes/ansible/roles/delete_chain/tasks/main.yaml`](diffhunk://#diff-63b68660ece5d8eef1afab31a59e49a1ed56a3c3a696e7d39520dac95ba376b6R1-R11): Added a task to execute the `delete_chain.py` script with required environment variables.