### PR TITLE
Add a fix for zero nodes and mirage node registration playbook

### DIFF
--- a/skale-nodes/ansible/files/fix_zero_node_mirage.py
+++ b/skale-nodes/ansible/files/fix_zero_node_mirage.py
@@ -22,8 +22,16 @@ from eth_typing import HexStr
 from skale import SkaleManager
 from skale.utils.web3_utils import init_web3
 from skale.wallets import Web3Wallet
-from skale.utils.contracts_provision.mirage import set_up_nodes
+from skale.wallets.web3_wallet import generate_wallet
+from skale.utils.contracts_provision.mirage import (
+    link_node_address, register_node, add_test_permissions, init_skale_from_wallet
+)
+from skale.utils.contracts_provision.main import (
+    set_test_msr, create_validator, enable_validator, validator_exist
+)
+from skale.utils.account_tools import send_eth
 
+ETH_AMOUNT = 0.2
 ENDPOINT = os.environ['ENDPOINT']
 ETH_PRIVATE_KEY = os.environ['ETH_PRIVATE_KEY']
 MANAGER_CONTRACTS = os.environ['MANAGER_CONTRACTS']
@@ -37,6 +45,32 @@ def init_skale_manager(
     return SkaleManager(endpoint, alias_or_address, wallet)
 
 
+def setup_validator(skale: SkaleManager):
+    """Create and activate a validator"""
+    set_test_msr(skale, msr=0)
+    print('Address', skale.wallet.address)
+    if not validator_exist(skale):
+        create_validator(skale)
+    else:
+        print('Skipping default validator creation')
+    validator_id = skale.validator_service.validator_id_by_address(skale.wallet.address)
+    if not skale.validator_service.get(validator_id)['trusted']:
+        enable_validator(skale, validator_id)
+
+
+def fix_zero_node(skale):
+    wallet = generate_wallet(skale.web3)
+    print(f'Node Address: {wallet.address}')
+    send_eth(skale.web3, skale.wallet, wallet.address, ETH_AMOUNT)
+    add_test_permissions(skale)
+    setup_validator(skale)
+    link_node_address(skale, wallet)
+    node_skale = init_skale_from_wallet(skale, wallet)
+    register_node(node_skale)
+    skale.nodes.init_exit(0)
+    skale.manager.node_exit(0)
+
+
 if __name__ == '__main__':
     skale = init_skale_manager(ENDPOINT, MANAGER_CONTRACTS, HexStr(ETH_PRIVATE_KEY))
-    set_up_nodes(skale, 0)
+    fix_zero_node(skale)

--- a/skale-nodes/ansible/files/transfer_funds.py
+++ b/skale-nodes/ansible/files/transfer_funds.py
@@ -20,7 +20,6 @@
 import os
 import logging
 
-from skale import SkaleManager
 from skale.wallets import Web3Wallet
 from skale.utils.web3_utils import init_web3
 from skale.utils.helper import init_default_logger
@@ -39,16 +38,11 @@ logger = logging.getLogger(__name__)
 init_default_logger()
 
 
-def init_web3_skale():
+def main():
     web3 = init_web3(ENDPOINT)
     wallet = Web3Wallet(ETH_PRIVATE_KEY, web3)
-    return SkaleManager(ENDPOINT, MANAGER_CONTRACTS, wallet)
-
-
-def main():
-    skale = init_web3_skale()
     address = to_checksum_address(ADDRESS)
-    send_eth(skale.web3, skale.wallet, address, AMOUNT)
+    send_eth(web3, wallet, address, AMOUNT)
 
 
 if __name__ == '__main__':

--- a/skale-nodes/ansible/main.yaml
+++ b/skale-nodes/ansible/main.yaml
@@ -1,10 +1,10 @@
 #- import_playbook: base.yaml
 #- import_playbook: geth.yaml
 - import_playbook: deploy_contracts.yaml
-- import_playbook: sgx_sim.yaml
-- import_playbook: setup.yaml
-- import_playbook: validator.yaml
-- import_playbook: signature.yaml
-- import_playbook: link_addresses.yaml
-- import_playbook: register.yaml
+#- import_playbook: sgx_sim.yaml
+#- import_playbook: setup.yaml
+#- import_playbook: validator.yaml
+#- import_playbook: signature.yaml
+#- import_playbook: link_addresses.yaml
+#- import_playbook: register.yaml
 #- import_playbook: ssl.yaml

--- a/skale-nodes/ansible/main.yaml
+++ b/skale-nodes/ansible/main.yaml
@@ -1,10 +1,10 @@
 #- import_playbook: base.yaml
 #- import_playbook: geth.yaml
 - import_playbook: deploy_contracts.yaml
-#- import_playbook: sgx_sim.yaml
-#- import_playbook: setup.yaml
-#- import_playbook: validator.yaml
-#- import_playbook: signature.yaml
-#- import_playbook: link_addresses.yaml
-#- import_playbook: register.yaml
+- import_playbook: sgx_sim.yaml
+- import_playbook: setup.yaml
+- import_playbook: validator.yaml
+- import_playbook: signature.yaml
+- import_playbook: link_addresses.yaml
+- import_playbook: register.yaml
 #- import_playbook: ssl.yaml

--- a/skale-nodes/ansible/main_mirage.yaml
+++ b/skale-nodes/ansible/main_mirage.yaml
@@ -1,5 +1,6 @@
 #- import_playbook: base.yaml
 - import_playbook: sgx_sim.yaml
 - import_playbook: setup.yaml
+- import_playbook: transfer_funds.yaml
 - import_playbook: register.yaml
 #- import_playbook: ssl.yaml

--- a/skale-nodes/ansible/main_mirage.yaml
+++ b/skale-nodes/ansible/main_mirage.yaml
@@ -1,0 +1,5 @@
+#- import_playbook: base.yaml
+- import_playbook: sgx_sim.yaml
+- import_playbook: setup.yaml
+- import_playbook: register.yaml
+#- import_playbook: ssl.yaml

--- a/skale-nodes/ansible/roles/deploy_contracts/tasks/manager.yaml
+++ b/skale-nodes/ansible/roles/deploy_contracts/tasks/manager.yaml
@@ -41,3 +41,16 @@
     line: 'manager_contracts: "{{ manager_contracts }}"'
     state: present
   tags: upload_sm
+
+- name: Hotfix for zero node in Mirage
+  run_once: yes
+  script: fix_zero_node_mirage.py
+  environment:
+    BASE_DIR: "files"
+    ETH_PRIVATE_KEY: "{{ eth_private_key }}"
+    ENDPOINT: "{{ endpoint }}"
+    MANAGER_CONTRACTS: "{{ manager_contracts }}"
+  args:
+    executable: python3
+  when: node_type == "mirage_boot"
+  tags: fix_zero_node

--- a/skale-nodes/ansible/roles/link_addresses/tasks/transfer_funds.yaml
+++ b/skale-nodes/ansible/roles/link_addresses/tasks/transfer_funds.yaml
@@ -1,14 +1,26 @@
 - name: Transfer funds to node wallets
   run_once: yes
-  script: transfer_funds.py
+  tags: node_funds
+  ansible.builtin.script: transfer_funds.py
   environment:
     ETH_PRIVATE_KEY: "{{ eth_private_key }}"
-    ADDRESS: "{{ lookup('file', '{{ item }}').split()[0].strip() }}"
-    ENDPOINT: "{{ endpoint }}"
-    MANAGER_CONTRACTS: "{{ manager_contracts }}"
+    ADDRESS: "{{ lookup('file', item).split()[0].strip() }}"
+    ENDPOINT: "{{ transfer_map[node_type].endpoint }}"
+    MANAGER_CONTRACTS: "{{ transfer_map[node_type].contracts }}"
     BASE_DIR: "files"
     AMOUNT: 0.2
   args:
     executable: python3
   with_fileglob: "node-info/*"
-  tags: node_funds
+  vars:
+    transfer_map:
+      mirage:
+        endpoint: "{{ boot_endpoint }}"
+        contracts: "{{ mirage_contracts }}"
+      mirage_boot:
+        endpoint: "{{ endpoint }}"
+        contracts: "{{ manager_contracts }}"
+      skale:
+        endpoint: "{{ endpoint }}"
+        contracts: "{{ manager_contracts }}"
+  when: node_type in transfer_map

--- a/skale-nodes/ansible/roles/register/tasks/main.yaml
+++ b/skale-nodes/ansible/roles/register/tasks/main.yaml
@@ -1,14 +1,3 @@
-- name: Hotfix for zero node in Mirage
-  script: fix_zero_node_mirage.py
-  environment:
-    BASE_DIR: "files"
-    ETH_PRIVATE_KEY: "{{ eth_private_key }}"
-    ENDPOINT: "{{ endpoint }}"
-    MANAGER_CONTRACTS: "{{ manager_contracts }}"
-  args:
-    executable: python3
-  when: node_type == "mirage_boot"
-
 - name: Register node
   command:
     cmd: "{{ node_commands[node_type] }}"

--- a/skale-nodes/ansible/roles/register/tasks/main.yaml
+++ b/skale-nodes/ansible/roles/register/tasks/main.yaml
@@ -4,7 +4,7 @@
   vars:
     node_commands:
       mirage_boot: "mirage boot register -n {{ inventory_hostname }} --ip {{ hostvars[inventory_hostname].ansible_host }} -p 10000 -d {{ inventory_hostname }}.{{ base_domain_name }}"
-      mirage: "mirage node register --ip {{ hostvars[inventory_hostname].ansible_host }} -p 10000 -d {{ inventory_hostname }}.{{ base_domain_name }}"
+      mirage: "mirage node register --ip {{ hostvars[inventory_hostname].ansible_host }}"
       skale: "skale node register -n {{ inventory_hostname }} --ip {{ hostvars[inventory_hostname].ansible_host }} -p 10000 -d {{ inventory_hostname }}.{{ base_domain_name }}"
   when: node_type in node_commands
   register: register_cmd

--- a/skale-nodes/ansible/transfer_funds.yaml
+++ b/skale-nodes/ansible/transfer_funds.yaml
@@ -1,0 +1,50 @@
+#- name: Prepare node information
+#  hosts: nodes
+#  tasks:
+#    - name: Save folder name for nodes addresses info
+#      set_fact:
+#        node_info_dir: "files/node-info"
+#      delegate_to: "127.0.0.1"
+#
+#    - name: Block for getting wallet info and saving it
+#      block:
+#
+#        - name: Get wallet info
+#          command:
+#            cmd: "{{ node_commands[node_type] }}"
+#          vars:
+#            node_commands:
+#              mirage_boot: "sudo mirage wallet info -f json"
+#              mirage: "sudo mirage wallet info -f json"
+#              skale: "sudo skale wallet info -f json"
+#          when: node_type in node_commands
+#          register: wallet_info_cmd
+#          changed_when: false
+#
+#        - name: Show wallet info command output
+#          debug:
+#            msg: "{{ wallet_info_cmd.stdout }}"
+#
+#        - name: Get wallet data from json
+#          set_fact:
+#            wallet_data: "{{ wallet_info_cmd.stdout | from_json }}"
+#
+#        - name: Show wallet info command output
+#          debug:
+#            msg: "{{ wallet_data.address }}"
+#
+#        - name: Save address to a file on the control node
+#          copy:
+#            content: "{{ wallet_data.address }}"
+#            dest: "{{ node_info_dir }}/{{ inventory_hostname }}"
+#          delegate_to: "127.0.0.1"
+
+- name: Transfer funds to node address
+  hosts: 127.0.0.1
+  connection: local
+  tasks:
+    - name: Transfer funds
+      import_role:
+        name: link_addresses
+        tasks_from: transfer_funds
+


### PR DESCRIPTION
This pull request introduces a new `fix_zero_node` function to address issues with zero nodes in the Mirage setup. It also updates the Ansible playbooks and task files to integrate this fix and refactor its placement for better organization and maintainability.

### Code Enhancements in Mirage Node Setup:

* Added the `fix_zero_node` function in `fix_zero_node_mirage.py`, which includes logic for generating wallets, sending ETH, setting up validators, linking node addresses, and registering nodes. This replaces the previous `set_up_nodes` function.
* Refactored imports in `fix_zero_node_mirage.py` to include additional utilities such as `generate_wallet`, `send_eth`, and validator-related functions for improved functionality.

### Updates to Ansible Playbooks:

* Updated `main_mirage.yaml` to include additional playbooks (`sgx_sim.yaml`, `setup.yaml`, and `register.yaml`) while commenting out unused ones (`base.yaml` and `ssl.yaml`).

### Task Refactoring in Ansible Roles:

* Moved the execution of the `fix_zero_node_mirage.py` script from the `register` role to the `deploy_contracts` role, ensuring it runs only once during the Mirage boot process. This improves task organization and avoids redundancy. [[1]](diffhunk://#diff-cf226f24cb57267a59e20abb3625b620f6a1c796e0bc7728b7270f4431308ce7R44-R56) [[2]](diffhunk://#diff-c2ae841ff8b0a40c1704f2c351fbc9e65d254c8d346770b72e6a28494146d25aL1-L11)