### PR TITLE
Add `set_rng` for FAIR chain and fix Transferring funds

### DIFF
--- a/skale-nodes/ansible/files/set_rng.py
+++ b/skale-nodes/ansible/files/set_rng.py
@@ -8,18 +8,16 @@ from skale import FairManager
 ENDPOINT = os.getenv('ENDPOINT')
 FAIR_CONTRACTS = os.getenv('FAIR_CONTRACTS')
 ETH_PRIVATE_KEY = os.getenv('ETH_PRIVATE_KEY')
+RNG_ADDRESS = '0x0000000000000000000000000000000000000018'
 
 
 def init_fair() -> FairManager:
     web3 = init_web3(ENDPOINT)
     wallet = Web3Wallet(HexStr(ETH_PRIVATE_KEY), web3)
-    if not FAIR_CONTRACTS:
-        raise ValueError('FAIR_CONTRACTS is not set')
     return FairManager(ENDPOINT, FAIR_CONTRACTS, wallet)
 
 
 if __name__ == '__main__':
     fair = init_fair()
-    rng_address = '0x0000000000000000000000000000000000000018'
     skale_rng = fair.committee.skale_rng()
-    fair.committee.set_rng(rng_address)
+    fair.committee.set_rng(RNG_ADDRESS)

--- a/skale-nodes/ansible/files/set_rng.py
+++ b/skale-nodes/ansible/files/set_rng.py
@@ -1,3 +1,22 @@
+#   -*- coding: utf-8 -*-
+#
+#   This file is part of node-provisioning
+#
+#   Copyright (C) 2025-Present SKALE Labs
+#
+#   node-provisioning is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   node-provisioning is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with node-provisioning.  If not, see <https://www.gnu.org/licenses/>.
+
 import os
 from eth_typing import HexStr
 from skale.utils.web3_utils import init_web3

--- a/skale-nodes/ansible/files/set_rng.py
+++ b/skale-nodes/ansible/files/set_rng.py
@@ -1,0 +1,25 @@
+import os
+from eth_typing import HexStr
+from skale.utils.web3_utils import init_web3
+from skale.wallets import Web3Wallet
+from skale import FairManager
+
+
+ENDPOINT = os.getenv('ENDPOINT')
+FAIR_CONTRACTS = os.getenv('FAIR_CONTRACTS')
+ETH_PRIVATE_KEY = os.getenv('ETH_PRIVATE_KEY')
+
+
+def init_fair() -> FairManager:
+    web3 = init_web3(ENDPOINT)
+    wallet = Web3Wallet(HexStr(ETH_PRIVATE_KEY), web3)
+    if not FAIR_CONTRACTS:
+        raise ValueError('FAIR_CONTRACTS is not set')
+    return FairManager(ENDPOINT, FAIR_CONTRACTS, wallet)
+
+
+if __name__ == '__main__':
+    fair = init_fair()
+    rng_address = '0x0000000000000000000000000000000000000018'
+    skale_rng = fair.committee.skale_rng()
+    fair.committee.set_rng(rng_address)

--- a/skale-nodes/ansible/requirements.txt
+++ b/skale-nodes/ansible/requirements.txt
@@ -1,3 +1,3 @@
 ansible==11.3.0
-skale.py==7.3.dev0
+skale.py==7.3.dev1
 boto3==1.17.34

--- a/skale-nodes/ansible/roles/fair_migrate/tasks/main.yaml
+++ b/skale-nodes/ansible/roles/fair_migrate/tasks/main.yaml
@@ -16,4 +16,6 @@
     FAIR_CONTRACTS: "{{ fair_contracts }}"
   args:
     executable: python3
+  delegate_to: localhost
+  run_once: true
   tags: set_nrg

--- a/skale-nodes/ansible/roles/fair_migrate/tasks/main.yaml
+++ b/skale-nodes/ansible/roles/fair_migrate/tasks/main.yaml
@@ -18,4 +18,5 @@
     executable: python3
   delegate_to: localhost
   run_once: true
+  become: false
   tags: set_rng

--- a/skale-nodes/ansible/roles/fair_migrate/tasks/main.yaml
+++ b/skale-nodes/ansible/roles/fair_migrate/tasks/main.yaml
@@ -6,3 +6,14 @@
 - name: Show migrate command output
   debug:
     msg: "{{ migrate_cmd.stdout }}"
+
+- name: Execute set_rng script
+  script: set_rng.py
+  environment:
+    BASE_DIR: "files"
+    ETH_PRIVATE_KEY: "{{ eth_private_key }}"
+    ENDPOINT: "{{ boot_endpoint }}"
+    FAIR_CONTRACTS: "{{ fair_contracts }}"
+  args:
+    executable: python3
+  tags: set_nrg

--- a/skale-nodes/ansible/roles/fair_migrate/tasks/main.yaml
+++ b/skale-nodes/ansible/roles/fair_migrate/tasks/main.yaml
@@ -18,4 +18,4 @@
     executable: python3
   delegate_to: localhost
   run_once: true
-  tags: set_nrg
+  tags: set_rng

--- a/skale-nodes/ansible/roles/link_addresses/tasks/transfer_funds.yaml
+++ b/skale-nodes/ansible/roles/link_addresses/tasks/transfer_funds.yaml
@@ -16,7 +16,7 @@
     transfer_map:
       fair:
         endpoint: "{{ boot_endpoint }}"
-        contracts: "{{ fair_contracts }}"
+        contracts: "{{ fair_contracts | default('') }}"
       fair_boot:
         endpoint: "{{ endpoint }}"
         contracts: "{{ manager_contracts }}"

--- a/skale-nodes/ansible/transfer_funds.yaml
+++ b/skale-nodes/ansible/transfer_funds.yaml
@@ -1,43 +1,43 @@
-#- name: Prepare node information
-#  hosts: nodes
-#  tasks:
-#    - name: Save folder name for nodes addresses info
-#      set_fact:
-#        node_info_dir: "files/node-info"
-#      delegate_to: "127.0.0.1"
-#
-#    - name: Block for getting wallet info and saving it
-#      block:
-#
-#        - name: Get wallet info
-#          command:
-#            cmd: "{{ node_commands[node_type] }}"
-#          vars:
-#            node_commands:
-#              fair_boot: "sudo fair wallet info -f json"
-#              fair: "sudo fair wallet info -f json"
-#              skale: "sudo skale wallet info -f json"
-#          when: node_type in node_commands
-#          register: wallet_info_cmd
-#          changed_when: false
-#
-#        - name: Show wallet info command output
-#          debug:
-#            msg: "{{ wallet_info_cmd.stdout }}"
-#
-#        - name: Get wallet data from json
-#          set_fact:
-#            wallet_data: "{{ wallet_info_cmd.stdout | from_json }}"
-#
-#        - name: Show wallet info command output
-#          debug:
-#            msg: "{{ wallet_data.address }}"
-#
-#        - name: Save address to a file on the control node
-#          copy:
-#            content: "{{ wallet_data.address }}"
-#            dest: "{{ node_info_dir }}/{{ inventory_hostname }}"
-#          delegate_to: "127.0.0.1"
+- name: Prepare node information
+  hosts: nodes
+  tasks:
+    - name: Save folder name for nodes addresses info
+      set_fact:
+        node_info_dir: "files/node-info"
+      delegate_to: "127.0.0.1"
+
+    - name: Block for getting wallet info and saving it
+      block:
+
+        - name: Get wallet info
+          command:
+            cmd: "{{ node_commands[node_type] }}"
+          vars:
+            node_commands:
+              fair_boot: "sudo fair wallet info -f json"
+              fair: "sudo fair wallet info -f json"
+              skale: "sudo skale wallet info -f json"
+          when: node_type in node_commands
+          register: wallet_info_cmd
+          changed_when: false
+
+        - name: Show wallet info command output
+          debug:
+            msg: "{{ wallet_info_cmd.stdout }}"
+
+        - name: Get wallet data from json
+          set_fact:
+            wallet_data: "{{ wallet_info_cmd.stdout | from_json }}"
+
+        - name: Show wallet info command output
+          debug:
+            msg: "{{ wallet_data.address }}"
+
+        - name: Save address to a file on the control node
+          copy:
+            content: "{{ wallet_data.address }}"
+            dest: "{{ node_info_dir }}/{{ inventory_hostname }}"
+          delegate_to: "127.0.0.1"
 
 - name: Transfer funds to node address
   hosts: 127.0.0.1


### PR DESCRIPTION
This pull request introduces a new `set_rng.py` script for managing the RNG address in the SKALE FairManager, updates dependencies, and adds related Ansible tasks. The changes enhance the automation of RNG address configuration and improve the flexibility of Ansible playbooks. Below are the most important changes:

### New Script for RNG Management:
* Added `set_rng.py` to initialize a FairManager instance and set the RNG address using the `skale.py` library. This script integrates with the SKALE ecosystem and uses environment variables for configuration. (`skale-nodes/ansible/files/set_rng.py`)

### Ansible Playbook Enhancements:
* Added a new task in `fair_migrate` to execute `set_rng.py` with the required environment variables, ensuring the RNG address is set during the provisioning process. (`skale-nodes/ansible/roles/fair_migrate/tasks/main.yaml`)
* Updated the `link_addresses` role to add a default value for `fair_contracts` in the `transfer_map` configuration, improving robustness when the variable is not explicitly set. (`skale-nodes/ansible/roles/link_addresses/tasks/transfer_funds.yaml`)

### Dependency Updates:
* Upgraded the `skale.py` library from version `7.3.dev0` to `7.3.dev1` to ensure compatibility with the new `set_rng.py` script. (`skale-nodes/ansible/requirements.txt`)

### Minor Adjustments:
* Added blank lines for formatting consistency in `transfer_funds.yaml`. (`skale-nodes/ansible/transfer_funds.yaml`) [[1]](diffhunk://#diff-98dee0058f5a88eeca511eb6966341e53cfef670ac0d5e808f6b4d95d3b304f0R11) [[2]](diffhunk://#diff-98dee0058f5a88eeca511eb6966341e53cfef670ac0d5e808f6b4d95d3b304f0R50)