### PR TITLE
Add 'change IP' functionality for FAIR nodes

### DIFF
--- a/skale-nodes/ansible/files/generate_ip.py
+++ b/skale-nodes/ansible/files/generate_ip.py
@@ -1,0 +1,11 @@
+import random
+import ipaddress
+
+def generate_random_ip() -> ipaddress.IPv4Address:
+    random_int = random.randint(0, 2**32 - 1)
+    ip_object = ipaddress.IPv4Address(random_int)
+    return ip_object
+
+if __name__ == '__main__':
+    random_ip_object = generate_random_ip()
+    print(random_ip_object)

--- a/skale-nodes/ansible/roles/cleanup_nodes/tasks/change_ip.yaml
+++ b/skale-nodes/ansible/roles/cleanup_nodes/tasks/change_ip.yaml
@@ -1,0 +1,21 @@
+- name: Generate random IP address
+  script: generate_ip.py
+  environment:
+    BASE_DIR: "files"
+  args:
+    executable: python3
+  register: random_ip
+  changed_when: false
+
+- name: Show generated IP
+  debug:
+    msg: "{{ random_ip }}"
+
+- name: Change node IP
+  command:
+    cmd: "fair node change-ip {{ random_ip.stdout | trim }}"
+  register: change_ip_cmd
+
+- name: Show change-ip command output
+  debug:
+    msg: "{{ change_ip_cmd.stdout }}"

--- a/skale-nodes/ansible/roles/cleanup_nodes/tasks/main.yaml
+++ b/skale-nodes/ansible/roles/cleanup_nodes/tasks/main.yaml
@@ -1,6 +1,7 @@
 - name: Change Fair node IP
   import_tasks: change_ip.yaml
   tags: change_ip
+  when: node_type == "fair"
 
 - name: Run container cleanup
   import_tasks: containers.yaml

--- a/skale-nodes/ansible/roles/cleanup_nodes/tasks/main.yaml
+++ b/skale-nodes/ansible/roles/cleanup_nodes/tasks/main.yaml
@@ -1,3 +1,7 @@
+- name: Change Fair node IP
+  import_tasks: change_ip.yaml
+  tags: change_ip
+
 - name: Run container cleanup
   import_tasks: containers.yaml
   tags: container_cleanup

--- a/skale-nodes/ansible/transfer_funds.yaml
+++ b/skale-nodes/ansible/transfer_funds.yaml
@@ -8,7 +8,6 @@
 
     - name: Block for getting wallet info and saving it
       block:
-
         - name: Get wallet info
           command:
             cmd: "{{ node_commands[node_type] }}"
@@ -47,4 +46,3 @@
       import_role:
         name: link_addresses
         tasks_from: transfer_funds
-


### PR DESCRIPTION
This pull request introduces a new functionality to generate and assign random IP addresses to "Fair" nodes in the `skale-nodes` Ansible setup. The most important changes are grouped below:

### New functionality: Random IP generation and assignment
* Added a new Python script, `generate_ip.py`, to generate random IPv4 addresses using the `ipaddress` and `random` modules.
* Introduced a new Ansible task file, `change_ip.yaml`, which:
  - Executes the `generate_ip.py` script to generate a random IP.
  - Changes the IP of "Fair" nodes using the `fair node change-ip` command with the generated IP.
* Updated the `main.yaml` task file to include the new `change_ip.yaml` tasks for "Fair" nodes, conditional on the `node_type` being "fair".