### PR TITLE
Add `fair passive-node cleanup` command

### DIFF
--- a/skale-nodes/ansible/roles/cleanup_nodes/tasks/cli_cleanup.yaml
+++ b/skale-nodes/ansible/roles/cleanup_nodes/tasks/cli_cleanup.yaml
@@ -1,9 +1,9 @@
 - name: Build and execute cleanup command
   command:
-    cmd: "{{ command_prefixes[node_type] }} node cleanup --yes"
+    cmd: "{{ command_prefixes[node_type] }} cleanup --yes"
   vars:
     command_prefixes:
-      fair: "fair"
+      fair: "{{ 'fair passive-node' if (passive_node | default(false) | bool) else 'fair node' }}"
   when: node_type in command_prefixes
   register: cleanup_cmd
 

--- a/skale-nodes/ansible/roles/config/tasks/main.yaml
+++ b/skale-nodes/ansible/roles/config/tasks/main.yaml
@@ -10,11 +10,6 @@
   when: ima_contracts is undefined
   tags: contracts
 
-- name: Set sgx url
-  set_fact:
-    sgx_url: "https://{{ hostvars['sgx0'].ansible_host }}:1026"
-  when: sgx_url is not defined or sgx_url == ''
-
 - name: Set env options for Fair boot node
   set_fact:
     env_options: |


### PR DESCRIPTION
This pull request updates the cleanup command logic in the Ansible role for node cleanup. The main change is to make the command prefix for `fair` nodes conditional based on whether the node is passive, and to simplify the command being run.
