### PR TITLE
Always run fix node id

### DIFF
--- a/skale-nodes/ansible/roles/deploy_contracts/tasks/manager.yaml
+++ b/skale-nodes/ansible/roles/deploy_contracts/tasks/manager.yaml
@@ -52,5 +52,4 @@
     MANAGER_CONTRACTS: "{{ manager_contracts }}"
   args:
     executable: python3
-  when: node_type == "fair_boot"
   tags: fix_zero_node


### PR DESCRIPTION
This pull request makes a minor change to the `manager.yaml` Ansible task by removing the conditional execution based on the `node_type`. The task will now always run, regardless of the node type.

- Removed the `when: node_type == "fair_boot"` condition from the Ansible task in `manager.yaml`, ensuring the task runs for all node types.