### PR TITLE
Support backup and restore commands for FAIR nodes

### DIFF
--- a/skale-nodes/ansible/backup.yaml
+++ b/skale-nodes/ansible/backup.yaml
@@ -1,3 +1,2 @@
 - import_playbook: backup_nodes.yaml
-- include_playbook: backup_schains.yaml
-  when: node_type is defined and node_type == 'skale'
+- import_playbook: backup_schains.yaml

--- a/skale-nodes/ansible/backup.yaml
+++ b/skale-nodes/ansible/backup.yaml
@@ -1,2 +1,0 @@
-- import_playbook: backup_nodes.yaml
-- import_playbook: backup_schains.yaml

--- a/skale-nodes/ansible/backup.yaml
+++ b/skale-nodes/ansible/backup.yaml
@@ -1,2 +1,3 @@
 - import_playbook: backup_nodes.yaml
-- import_playbook: backup_schains.yaml
+- include_playbook: backup_schains.yaml
+  when: node_type is defined and node_type == 'skale'

--- a/skale-nodes/ansible/backup_nodes.yaml
+++ b/skale-nodes/ansible/backup_nodes.yaml
@@ -1,6 +1,4 @@
 - name: Backup node
   hosts: nodes
-  vars:
-    - ip_address: "{{ hostvars[inventory_hostname].ansible_host }}"
   roles:
     - node_backup

--- a/skale-nodes/ansible/backup_nodes.yaml
+++ b/skale-nodes/ansible/backup_nodes.yaml
@@ -1,4 +1,7 @@
-- name: Backup node
+- name: Backup SKALE or FAIR nodes
   hosts: nodes
+
   roles:
-    - node_backup
+    - role: node_backup
+      when: node_type is defined and node_type in ['skale', 'fair']
+      tags: backup_node

--- a/skale-nodes/ansible/backup_schains.yaml
+++ b/skale-nodes/ansible/backup_schains.yaml
@@ -1,19 +1,17 @@
-- name: Validate node_type
-  hosts: nodes
+- name: Fetch schain nodes script
+  hosts: localhost
+  connection: local
   gather_facts: false
+  serial: True
+
   tasks:
     - name: Validate node_type
       fail:
         msg: >
-          The 'node_type' variable must be defined and set to 'skale'.
+          The 'node_type' variable must be defined and set to 'skale' for sChain backup.
           Current value: '{{ node_type | default('undefined') }}'
       when: node_type is not defined or node_type != 'skale'
 
-- name: Fetch schain nodes script
-  hosts: localhost
-  serial: True
-
-  tasks:
     - name: Run fetch schain nodes script
       script: fetch_node_schains.py -u
       environment:

--- a/skale-nodes/ansible/backup_schains.yaml
+++ b/skale-nodes/ansible/backup_schains.yaml
@@ -1,3 +1,14 @@
+- name: Validate node_type
+  hosts: nodes
+  gather_facts: false
+  tasks:
+    - name: Validate node_type
+      fail:
+        msg: >
+          The 'node_type' variable must be defined and set to 'skale'.
+          Current value: '{{ node_type | default('undefined') }}'
+      when: node_type is not defined or node_type != 'skale'
+
 - name: Fetch schain nodes script
   hosts: localhost
   serial: True

--- a/skale-nodes/ansible/backup_schains.yaml
+++ b/skale-nodes/ansible/backup_schains.yaml
@@ -32,7 +32,7 @@
         node_schains: "{{ hostvars['localhost'].node_schains }}"
 
     - name: Make snapshot
-      include: tasks/schains_backup.yaml
+      include_tasks: tasks/schains_backup.yaml
       vars:
         schains: "{{ node_schains[ip_address] }}"
       when: ip_address in node_schains

--- a/skale-nodes/ansible/restore.yaml
+++ b/skale-nodes/ansible/restore.yaml
@@ -1,7 +1,0 @@
-- import_playbook: restore_node.yaml
-  vars:
-    config_only: True
-
-- import_playbook: restore_schain.yaml
-
-- import_playbook: update.yaml

--- a/skale-nodes/ansible/restore_node.yaml
+++ b/skale-nodes/ansible/restore_node.yaml
@@ -1,8 +1,7 @@
-- name: Restore node from backup tarball
+- name: Restore SKALE or FAIR nodes from backup tarball
   hosts: nodes
-  vars:
-    - ip_address: "{{ hostvars[inventory_hostname].ansible_host }}"
 
   roles:
     - role: node_restore
+      when: node_type is defined and node_type in ['skale', 'fair']
       tags: restore_node

--- a/skale-nodes/ansible/restore_schain.yaml
+++ b/skale-nodes/ansible/restore_schain.yaml
@@ -1,9 +1,18 @@
 - name: Fetch schain nodes script
   hosts: localhost
+  connection: local
+  gather_facts: false
   serial: True
 
   tasks:
-    - name: Fetch nodes schains script
+    - name: Validate node_type
+      fail:
+        msg: >
+          The 'node_type' variable must be defined and set to 'skale' for sChain restore.
+          Current value: '{{ node_type | default('undefined') }}'
+      when: node_type is not defined or node_type != 'skale'
+
+    - name: Run fetch schain nodes script
       script: fetch_node_schains.py
       environment:
         ETH_PRIVATE_KEY: "{{ eth_private_key }}"

--- a/skale-nodes/ansible/roles/node_backup/tasks/main.yaml
+++ b/skale-nodes/ansible/roles/node_backup/tasks/main.yaml
@@ -1,4 +1,2 @@
-- name: Backup node
-  import_tasks:
-    file: node.yaml
-  tags: node
+- import_tasks: node.yaml
+  tags: [backup_node]

--- a/skale-nodes/ansible/roles/node_backup/tasks/node.yaml
+++ b/skale-nodes/ansible/roles/node_backup/tasks/node.yaml
@@ -1,9 +1,20 @@
+- name: Validate node_type
+  fail:
+    msg: >
+      The 'node_type' variable must be defined and set to either 'skale' or 'fair'.
+      Current value: '{{ node_type | default('undefined') }}'
+  when: node_type is not defined or node_type not in ['skale', 'fair']
+
 - name: Setting backup archive folder
   set_fact: backup_path="{{ base_path }}/backup"
 
+- name: Set node command prefix
+  set_fact:
+    node_cmd_prefix: "{{ 'fair' if node_type == 'fair' else 'skale' }}"
+
 - name: Turn off the node
   command:
-    cmd: "skale node turn-off --yes"
+    cmd: "{{ node_cmd_prefix }} node turn-off --yes"
   when: not no_downtime is defined or not no_downtime
   become: true
 
@@ -15,7 +26,7 @@
 
 - name: Create backup archive
   command:
-    cmd: "skale node backup {{ backup_path }}"
+    cmd: "{{ node_cmd_prefix }} node backup {{ backup_path }}"
   become: true
 
 - name: Create sgx sim backup
@@ -28,7 +39,7 @@
 
 - name: Turn on the node back
   command:
-    cmd: "skale node turn-on {{ base_path }}/init-env --yes"
+    cmd: "{{ node_cmd_prefix }} node turn-on {{ base_path }}/init-env --yes"
   when: not no_downtime is defined or not no_downtime
   become: true
 

--- a/skale-nodes/ansible/roles/node_restore/tasks/main.yaml
+++ b/skale-nodes/ansible/roles/node_restore/tasks/main.yaml
@@ -1,1 +1,2 @@
-- include: node.yaml
+- import_tasks: node.yaml
+  tags: [restore_node]

--- a/skale-nodes/ansible/roles/node_restore/tasks/node.yaml
+++ b/skale-nodes/ansible/roles/node_restore/tasks/node.yaml
@@ -1,3 +1,14 @@
+- name: Validate node_type
+  fail:
+    msg: >
+      The 'node_type' variable must be defined and set to either 'skale' or 'fair'.
+      Current value: '{{ node_type | default('undefined') }}'
+  when: node_type is not defined or node_type not in ['skale', 'fair']
+
+- name: Set node command prefix
+  set_fact:
+    node_cmd_prefix: "{{ 'fair' if node_type == 'fair' else 'skale' }}"
+
 - name: Lookup backupfile
   delegate_to: localhost
   find:
@@ -11,7 +22,7 @@
 
 - name: Get latest backup
   set_fact:
-    backup_name: "{{ (search_result.files | sort(attribute='mtime'))[-1].path | basename }}"
+    backup_name: "{{ (search_result.files | sort(attribute='mtime', reverse=true) | first).path | basename }}"
 
 - name: Upload node backup file
   copy:
@@ -25,17 +36,18 @@
 
 - name: Compose regular cmd
   set_fact:
-    cmd: "skale node restore {{ base_path }}/backup.tar.gz {{ base_path }}/init-env"
+    cmd: "{{ node_cmd_prefix }} node restore {{ base_path }}/backup.tar.gz {{ base_path }}/init-env"
   when: config_only is not defined or not config_only
 
 - name: Compose cmd with config only
   set_fact:
-    cmd: "skale node restore --config-only {{ base_path }}/backup.tar.gz {{ base_path }}/init-env"
-  when: config_only is defined and config_only
+    cmd: "{{ node_cmd_prefix }} node restore --config-only {{ base_path }}/backup.tar.gz {{ base_path }}/init-env"
+  when:
+    - node_type == "skale"
+    - config_only is defined and config_only
 
-- name: Run skale node restore
+- name: Run skale/fair node restore
   shell:
     cmd: "{{ cmd }}"
   environment:
     HOME_DIR: "{{ base_path }}"
-  tags: skale_restore


### PR DESCRIPTION
This pull request refactors and improves the Ansible playbooks and roles for backing up and restoring SKALE and FAIR nodes. The changes introduce stricter validation of node types, make command execution generic for both SKALE and FAIR nodes, and improve playbook structure and task usage. The updates help prevent misconfiguration and ensure that backup and restore operations are only performed on supported node types.

**Validation and Safety Improvements:**

* Added validation tasks to ensure the `node_type` variable is defined and set to either `'skale'` or `'fair'` before proceeding with backup or restore operations in `node_backup` and `node_restore` roles, and in sChain playbooks [[1]](diffhunk://#diff-608b92b5d63563d6015b8bc0662cefead15e3ad89f14cd8ec66fb39a088e8411R1-R17) [[2]](diffhunk://#diff-3953ba62956d0dcabd38da3619a9b3a0438f147e67ecf1096bfd758add356a59R1-R11) [[3]](diffhunk://#diff-39cdc101dd772ed3c1a4458142689186981fbaa62de86b73093b873d9faa88b5R3-R14).
* Added validation to sChain backup and restore playbooks to ensure `node_type` is `'skale'` [[1]](diffhunk://#diff-39cdc101dd772ed3c1a4458142689186981fbaa62de86b73093b873d9faa88b5R3-R14) [[2]](diffhunk://#diff-88ff4697da25286943861f49a0a81b02ec3747f6dac08686d5a9891ea34a3ef7R3-R15).

**Generic Node Command Handling:**

* Refactored command construction to use a `node_cmd_prefix` variable, enabling commands to run for both SKALE and FAIR nodes [[1]](diffhunk://#diff-608b92b5d63563d6015b8bc0662cefead15e3ad89f14cd8ec66fb39a088e8411R1-R17) [[2]](diffhunk://#diff-608b92b5d63563d6015b8bc0662cefead15e3ad89f14cd8ec66fb39a088e8411L18-R29) [[3]](diffhunk://#diff-608b92b5d63563d6015b8bc0662cefead15e3ad89f14cd8ec66fb39a088e8411L31-R42) [[4]](diffhunk://#diff-3953ba62956d0dcabd38da3619a9b3a0438f147e67ecf1096bfd758add356a59R1-R11) [[5]](diffhunk://#diff-3953ba62956d0dcabd38da3619a9b3a0438f147e67ecf1096bfd758add356a59L28-L41).

**Playbook and Task Structure Enhancements:**

* Updated playbooks and roles to use `import_tasks`/`include_tasks` instead of deprecated `include` statements, and improved tagging for easier task selection [[1]](diffhunk://#diff-3a7e676103ec0b654d6953fe510d85c8406701b5d69f9f090df8aa201de4d298L1-R2) [[2]](diffhunk://#diff-31fc3890ea4348cf8fea8992f20d56ff03c078e27185f8f4c441a692d4427634L1-R2) [[3]](diffhunk://#diff-39cdc101dd772ed3c1a4458142689186981fbaa62de86b73093b873d9faa88b5L35-R44).
* Added `connection: local` and `gather_facts: false` to sChain playbooks for clarity and performance [[1]](diffhunk://#diff-39cdc101dd772ed3c1a4458142689186981fbaa62de86b73093b873d9faa88b5R3-R14) [[2]](diffhunk://#diff-88ff4697da25286943861f49a0a81b02ec3747f6dac08686d5a9891ea34a3ef7R3-R15).

**Backup and Restore Logic Improvements:**

* Improved logic for selecting the latest backup file using a more robust sorting method.
* Ensured config-only restore is only available for SKALE nodes and not for FAIR nodes.

**Deprecated Playbooks Removal:**

* Removed old playbooks (`backup.yaml`, `restore.yaml`) and their imports to streamline the workflow and avoid confusion [[1]](diffhunk://#diff-b56a269004b9b4f73fbb88cd089e8d52cc30a3527e0ca0e1a56ed5325f412b50L1-L2) [[2]](diffhunk://#diff-992e42a4930f9e22b8cc216d5a18180758aec349ca527bcaf5461f9902fbacedL1-L7).