### PR TITLE
Add `deploy_fair` and `whitelist_and_stake` tags

### DIFF
--- a/skale-nodes/ansible/roles/deploy_fair/tasks/main.yaml
+++ b/skale-nodes/ansible/roles/deploy_fair/tasks/main.yaml
@@ -1,2 +1,5 @@
 - import_tasks: deploy_fair.yaml
+  tags: [deploy_fair]
 - import_tasks: whitelist_and_stake.yaml
+  tags: [whitelist_and_stake]
+


### PR DESCRIPTION
This pull request makes a small change to the `skale-nodes/ansible/roles/deploy_fair/tasks/main.yaml` file by adding tags to the imported tasks. This will allow for more granular control when running Ansible playbooks.