### PR TITLE
update node provisioning - new settings structure

### DIFF
--- a/skale-nodes/ansible/roles/config/tasks/main.yaml
+++ b/skale-nodes/ansible/roles/config/tasks/main.yaml
@@ -19,7 +19,7 @@
       ENDPOINT="{{ endpoint }}"
       CONTAINER_CONFIGS_DIR="{{ container_configs_dir if (build_type | default('')) == 'source' else ''}}"
       BLOCK_DEVICE="{{ block_device }}"
-      SGX_SERVER_URL="{{ sgx_url }}"
+      SGX_URL="{{ sgx_url }}"
       ENV_TYPE="{{ env_type }}"
       FILEBEAT_HOST="{{ filebeat_host }}"
       ENFORCE_BTRFS='False'
@@ -40,9 +40,9 @@
   when: node_type == "fair"
   tags: env
 
-- name: Add SGX_SERVER_URL to env options if not passive
+- name: Add SGX_URL to env options if not passive
   set_fact:
-    env_options: "{{ env_options }}\nSGX_SERVER_URL={{ sgx_url }}"
+    env_options: "{{ env_options }}\nSGX_URL={{ sgx_url }}"
   when:
     - node_type == "fair"
     - passive_node is not defined or not passive_node
@@ -59,14 +59,13 @@
       CONTAINER_CONFIGS_DIR="{{ container_configs_dir if (build_type | default('')) == 'source' else ''}}"
       DOCKER_LVMPY_VERSION="{{ docker_lvmpy_version }}"
       BLOCK_DEVICE="{{ block_device }}"
-      SGX_SERVER_URL="{{ sgx_url }}"
+      SGX_URL="{{ sgx_url }}"
       TG_API_KEY="{{ tg_api_key }}"
       TG_CHAT_ID="{{ tg_chat_id }}"
       MONITORING_CONTAINERS="{{ monitoring_containers }}"
       DEFAULT_GAS_PRICE_WEI="{{ default_gas_price_wei }}"
       ENV_TYPE="{{ env_type }}"
       INFLUX_URL="{{ influx_url }}"
-      TELEGRAF="{{ telegraf }}"
   when:
     - node_type == "skale"
     - (passive_node is not defined or not passive_node)

--- a/skale-nodes/ansible/roles/sync/templates/docker-compose-fair.yml.j2
+++ b/skale-nodes/ansible/roles/sync/templates/docker-compose-fair.yml.j2
@@ -20,11 +20,6 @@ services:
       network: host
     network_mode: host
     tty: true
-    environment:
-      SGX_URL: ${SGX_SERVER_URL}
-      ENDPOINT: ${ENDPOINT}
-      BOOT_ENDPOINT: ${BOOT_ENDPOINT}
-      CONFIRMATION_BLOCKS: 0
     volumes:
       - ${SKALE_DIR}:/skale_vol
       - ${SKALE_DIR}/node_data:/skale_node_data
@@ -43,25 +38,6 @@ services:
     cap_add:
       - NET_ADMIN
       - NET_RAW
-    environment:
-      SGX_SERVER_URL: ${SGX_SERVER_URL}
-      SGX_CERTIFICATES_DIR_NAME: ${SGX_CERTIFICATES_DIR_NAME}
-      ENDPOINT: ${ENDPOINT}
-      SKALE_DIR_HOST: ${SKALE_DIR}
-      MONITORING_CONTAINERS: ${MONITORING_CONTAINERS}
-      BACKUP_RUN: ${BACKUP_RUN}
-      DISABLE_DRY_RUN: ${DISABLE_DRY_RUN}
-      DEFAULT_GAS_LIMIT: ${DEFAULT_GAS_LIMIT}
-      DEFAULT_GAS_PRICE_WEI: ${DEFAULT_GAS_PRICE_WEI}
-      MAX_ALLOWED_LOG_TIME_DIFF: 600
-      ENV_TYPE: ${ENV_TYPE}
-      ALLOWED_TS_DIFF: 300
-      TELEGRAF: ${TELEGRAF}
-      INFLUX_URL: ${INFLUX_URL}
-      MANAGER_CONTRACTS: ${MANAGER_CONTRACTS}
-      IMA_CONTRACTS: ${IMA_CONTRACTS}
-      SKALE_NETWORK_TYPE: "fair"
-
     command: "python3 admin.py"
     volumes:
       - /var/run/skale:/var/run/skale
@@ -90,25 +66,6 @@ services:
     cap_add:
       - NET_ADMIN
       - NET_RAW
-    environment:
-      SGX_SERVER_URL: ${SGX_SERVER_URL}
-      SGX_CERTIFICATES_DIR_NAME: ${SGX_CERTIFICATES_DIR_NAME}
-      BOOT_ENDPOINT: ${BOOT_ENDPOINT}
-      SKALE_DIR_HOST: ${SKALE_DIR}
-      MONITORING_CONTAINERS: ${MONITORING_CONTAINERS}
-      BACKUP_RUN: ${BACKUP_RUN}
-      DISABLE_DRY_RUN: ${DISABLE_DRY_RUN}
-      DEFAULT_GAS_LIMIT: ${DEFAULT_GAS_LIMIT}
-      DEFAULT_GAS_PRICE_WEI: ${DEFAULT_GAS_PRICE_WEI}
-      MAX_ALLOWED_LOG_TIME_DIFF: 600
-      ENV_TYPE: ${ENV_TYPE}
-      ALLOWED_TS_DIFF: 300
-      TELEGRAF: ${TELEGRAF}
-      INFLUX_URL: ${INFLUX_URL}
-      FAIR_CONTRACTS: ${FAIR_CONTRACTS}
-      SKALE_NETWORK_TYPE: "fair"
-      PASSIVE_NODE: ${PASSIVE_NODE}
-
     command: "python3 fair.py"
     volumes:
       - /var/run/skale:/var/run/skale
@@ -136,25 +93,6 @@ services:
     cap_add:
       - NET_ADMIN
       - NET_RAW
-    environment:
-      SGX_SERVER_URL: ${SGX_SERVER_URL}
-      SGX_CERTIFICATES_DIR_NAME: ${SGX_CERTIFICATES_DIR_NAME}
-      ENDPOINT: ${ENDPOINT}
-      FLASK_SECRET_KEY: ${FLASK_SECRET_KEY}
-      FLASK_APP_PORT: 3007
-      FLASK_APP_HOST: "127.0.0.1"
-      FLASK_DEBUG_MODE: "False"
-      SKALE_DIR_HOST: ${SKALE_DIR}
-      MONITORING_CONTAINERS: ${MONITORING_CONTAINERS}
-      BACKUP_RUN: ${BACKUP_RUN}
-      DISABLE_DRY_RUN: ${DISABLE_DRY_RUN}
-      DEFAULT_GAS_LIMIT: ${DEFAULT_GAS_LIMIT}
-      DEFAULT_GAS_PRICE_WEI: ${DEFAULT_GAS_PRICE_WEI}
-      ENV_TYPE: ${ENV_TYPE}
-      ALLOWED_TS_DIFF: 300
-      MANAGER_CONTRACTS: ${MANAGER_CONTRACTS}
-      IMA_CONTRACTS: ${IMA_CONTRACTS}
-      SKALE_NETWORK_TYPE: "fair"
     command: "gunicorn app:app -c gunicorn.conf.py"
     volumes:
       - /var/run/skale:/var/run/skale
@@ -176,25 +114,6 @@ services:
     cap_add:
       - NET_ADMIN
       - NET_RAW
-    environment:
-      SGX_SERVER_URL: ${SGX_SERVER_URL}
-      SGX_CERTIFICATES_DIR_NAME: ${SGX_CERTIFICATES_DIR_NAME}
-      BOOT_ENDPOINT: ${BOOT_ENDPOINT}
-      FLASK_SECRET_KEY: ${FLASK_SECRET_KEY}
-      FLASK_APP_PORT: 3007
-      FLASK_APP_HOST: "127.0.0.1"
-      FLASK_DEBUG_MODE: "False"
-      SKALE_DIR_HOST: ${SKALE_DIR}
-      MONITORING_CONTAINERS: ${MONITORING_CONTAINERS}
-      BACKUP_RUN: ${BACKUP_RUN}
-      DISABLE_DRY_RUN: ${DISABLE_DRY_RUN}
-      DEFAULT_GAS_LIMIT: ${DEFAULT_GAS_LIMIT}
-      DEFAULT_GAS_PRICE_WEI: ${DEFAULT_GAS_PRICE_WEI}
-      ENV_TYPE: ${ENV_TYPE}
-      ALLOWED_TS_DIFF: 300
-      FAIR_CONTRACTS: ${FAIR_CONTRACTS}
-      SKALE_NETWORK_TYPE: "fair"
-      PASSIVE_NODE: ${PASSIVE_NODE}
     command: "gunicorn fair_api:app -c gunicorn.conf.py"
     volumes:
       - /var/run/skale:/var/run/skale

--- a/skale-nodes/ansible/roles/sync/templates/docker-compose.yml.j2
+++ b/skale-nodes/ansible/roles/sync/templates/docker-compose.yml.j2
@@ -20,9 +20,6 @@ services:
       network: host
     network_mode: host
     tty: true
-    environment:
-      SGX_URL: ${SGX_SERVER_URL}
-      ENDPOINT: ${ENDPOINT}
     volumes:
       - ${SKALE_DIR}:/skale_vol
       - ${SKALE_DIR}/node_data:/skale_node_data
@@ -41,27 +38,6 @@ services:
     cap_add:
       - NET_ADMIN
       - NET_RAW
-    environment:
-      SGX_SERVER_URL: ${SGX_SERVER_URL}
-      SGX_CERTIFICATES_DIR_NAME: ${SGX_CERTIFICATES_DIR_NAME}
-      ENDPOINT: ${ENDPOINT}
-      SKALE_DIR_HOST: ${SKALE_DIR}
-      TG_API_KEY: ${TG_API_KEY}
-      TG_CHAT_ID: ${TG_CHAT_ID}
-      MONITORING_CONTAINERS: ${MONITORING_CONTAINERS}
-      BACKUP_RUN: ${BACKUP_RUN}
-      DISABLE_DRY_RUN: ${DISABLE_DRY_RUN}
-      DEFAULT_GAS_LIMIT: ${DEFAULT_GAS_LIMIT}
-      DEFAULT_GAS_PRICE_WEI: ${DEFAULT_GAS_PRICE_WEI}
-      MAX_ALLOWED_LOG_TIME_DIFF: 600
-      ENV_TYPE: ${ENV_TYPE}
-      ALLOWED_TS_DIFF: 300
-      PULL_CONFIG_FOR_SCHAIN: ${PULL_CONFIG_FOR_SCHAIN}
-      TELEGRAF: ${TELEGRAF}
-      INFLUX_URL: ${INFLUX_URL}
-      MANAGER_CONTRACTS: ${MANAGER_CONTRACTS}
-      IMA_CONTRACTS: ${IMA_CONTRACTS}
-
     command: "python3 admin.py"
     volumes:
       - /var/run/skale:/var/run/skale
@@ -88,26 +64,6 @@ services:
     cap_add:
       - NET_ADMIN
       - NET_RAW
-    environment:
-      SGX_SERVER_URL: ${SGX_SERVER_URL}
-      SGX_CERTIFICATES_DIR_NAME: ${SGX_CERTIFICATES_DIR_NAME}
-      ENDPOINT: ${ENDPOINT}
-      FLASK_SECRET_KEY: ${FLASK_SECRET_KEY}
-      FLASK_APP_PORT: 3007
-      FLASK_APP_HOST: "127.0.0.1"
-      FLASK_DEBUG_MODE: "False"
-      SKALE_DIR_HOST: ${SKALE_DIR}
-      TG_API_KEY: ${TG_API_KEY}
-      TG_CHAT_ID: ${TG_CHAT_ID}
-      MONITORING_CONTAINERS: ${MONITORING_CONTAINERS}
-      BACKUP_RUN: ${BACKUP_RUN}
-      DISABLE_DRY_RUN: ${DISABLE_DRY_RUN}
-      DEFAULT_GAS_LIMIT: ${DEFAULT_GAS_LIMIT}
-      DEFAULT_GAS_PRICE_WEI: ${DEFAULT_GAS_PRICE_WEI}
-      ENV_TYPE: ${ENV_TYPE}
-      ALLOWED_TS_DIFF: 300
-      MANAGER_CONTRACTS: ${MANAGER_CONTRACTS}
-      IMA_CONTRACTS: ${IMA_CONTRACTS}
     command: "gunicorn app:app -c gunicorn.conf.py"
     volumes:
       - /var/run/skale:/var/run/skale
@@ -125,10 +81,6 @@ services:
       network: host
     network_mode: host
     tty: true
-    environment:
-      TG_API_KEY: ${TG_API_KEY}
-      TG_CHAT_ID: ${TG_CHAT_ID}
-      SKALE_DIR_HOST: ${SKALE_DIR}
     command: "celery -A tools.notifications.tasks worker --loglevel=info"
 
     volumes:
@@ -156,16 +108,6 @@ services:
       dockerfile: Dockerfile
       network: host
     network_mode: host
-    environment:
-      SGX_SERVER_URL: ${SGX_SERVER_URL}
-      SGX_CERTIFICATES_DIR_NAME: ${SGX_CERTIFICATES_DIR_NAME}
-      ENDPOINT: ${ENDPOINT}
-      DISABLE_DRY_RUN: ${DISABLE_DRY_RUN}
-      DEFAULT_GAS_LIMIT: ${DEFAULT_GAS_LIMIT}
-      DEFAULT_GAS_PRICE_WEI: ${DEFAULT_GAS_PRICE_WEI}
-      ALLOWED_TS_DIFF: 300
-      MANAGER_CONTRACTS: ${MANAGER_CONTRACTS}
-      IMA_CONTRACTS: ${IMA_CONTRACTS}
     volumes:
       - ${SKALE_DIR}:/skale_vol
       - ${SKALE_DIR}/node_data:/skale_node_data


### PR DESCRIPTION
This pull request standardizes the use of the `SGX_URL` environment variable across Ansible roles and Docker Compose templates, replacing the previous `SGX_SERVER_URL` naming. Additionally, it removes many explicit `environment` sections from the Docker Compose YAML templates, likely to streamline configuration management and reduce redundancy.

**Environment Variable Standardization:**

* Replaced all instances of `SGX_SERVER_URL` with `SGX_URL` in the Ansible `main.yaml` configuration tasks and related environment variable assignments. [[1]](diffhunk://#diff-cbf3ade899efca54851e40fb60819d1afa3de0ca63f313cbc31e4ace2b1d5a00L22-R22) [[2]](diffhunk://#diff-cbf3ade899efca54851e40fb60819d1afa3de0ca63f313cbc31e4ace2b1d5a00L43-R45) [[3]](diffhunk://#diff-cbf3ade899efca54851e40fb60819d1afa3de0ca63f313cbc31e4ace2b1d5a00L62-L69)

**Docker Compose Template Cleanup:**

* Removed the `environment` sections from multiple services in both `docker-compose-fair.yml.j2` and `docker-compose.yml.j2`, eliminating explicit environment variable definitions (including `SGX_SERVER_URL`, `SGX_URL`, and others) from these templates. [[1]](diffhunk://#diff-011e6e6aab7c7f97eeb5a34fdfb40d056af5e9d0151dea72f22c9607ada20d4fL23-L27) [[2]](diffhunk://#diff-011e6e6aab7c7f97eeb5a34fdfb40d056af5e9d0151dea72f22c9607ada20d4fL46-L64) [[3]](diffhunk://#diff-011e6e6aab7c7f97eeb5a34fdfb40d056af5e9d0151dea72f22c9607ada20d4fL93-L111) [[4]](diffhunk://#diff-011e6e6aab7c7f97eeb5a34fdfb40d056af5e9d0151dea72f22c9607ada20d4fL139-L157) [[5]](diffhunk://#diff-011e6e6aab7c7f97eeb5a34fdfb40d056af5e9d0151dea72f22c9607ada20d4fL179-L197) [[6]](diffhunk://#diff-e3db7866a92845aec45518c316ee46a3b09e90a41357a525795f2932a503f16bL23-L25) [[7]](diffhunk://#diff-e3db7866a92845aec45518c316ee46a3b09e90a41357a525795f2932a503f16bL44-L64) [[8]](diffhunk://#diff-e3db7866a92845aec45518c316ee46a3b09e90a41357a525795f2932a503f16bL91-L110) [[9]](diffhunk://#diff-e3db7866a92845aec45518c316ee46a3b09e90a41357a525795f2932a503f16bL128-L131) [[10]](diffhunk://#diff-e3db7866a92845aec45518c316ee46a3b09e90a41357a525795f2932a503f16bL159-L168)

These changes help ensure consistent environment variable usage and likely shift responsibility for environment variable injection elsewhere in the deployment process.