### PR TITLE
Add bite option to init-env

### DIFF
--- a/skale-nodes/ansible/inventory-template/dev
+++ b/skale-nodes/ansible/inventory-template/dev
@@ -30,6 +30,8 @@ env_type=''
 sgx_version=''
 cert_mode='certbot/custom'
 
+bite=False
+
 influx_url='http://example.com'
 
 ## dev variables (skip if env=test)

--- a/skale-nodes/ansible/roles/config/tasks/main.yaml
+++ b/skale-nodes/ansible/roles/config/tasks/main.yaml
@@ -66,6 +66,7 @@
       DEFAULT_GAS_PRICE_WEI="{{ default_gas_price_wei }}"
       ENV_TYPE="{{ env_type }}"
       INFLUX_URL="{{ influx_url }}"
+      BITE="{{ bite }}"
   when:
     - node_type == "skale"
     - (passive_node is not defined or not passive_node)


### PR DESCRIPTION
This pull request introduces a new configuration variable called `bite` to the SKALE node Ansible setup. The variable is added to both the inventory template and the configuration tasks, allowing it to be passed as an environment variable during node configuration.

Configuration variable addition:

* Added a new variable `bite` (defaulting to `False`) to the `skale-nodes/ansible/inventory-template/dev` file.
* Updated the environment variables in `skale-nodes/ansible/roles/config/tasks/main.yaml` to include `BITE="{{ bite }}"` when configuring nodes.