### PR TITLE
add settings volume to watchdog

### DIFF
--- a/skale-nodes/ansible/roles/sync/templates/docker-compose.yml.j2
+++ b/skale-nodes/ansible/roles/sync/templates/docker-compose.yml.j2
@@ -121,6 +121,8 @@ services:
       dockerfile: Dockerfile
       network: host
     network_mode: host
+    volumes:
+      - ${SKALE_DIR}/node_data/settings:/settings:ro
     environment:
       ALLOWED_TS_DIFF: 300
       FLASK_APP_PORT: 3010


### PR DESCRIPTION
This pull request introduces a minor configuration update to the `docker-compose.yml.j2` template. The change mounts the node settings directory as a read-only volume, which helps ensure the container has access to necessary configuration files without risking modification.

* Added a volume mount for `${SKALE_DIR}/node_data/settings` as `/settings` (read-only) in the service definition of `docker-compose.yml.j2`.