### PR TITLE
Fix template

### DIFF
--- a/skale-nodes/ansible/ansible.cfg
+++ b/skale-nodes/ansible/ansible.cfg
@@ -1,3 +1,4 @@
 [defaults]
 host_key_checking = False
 stdout_callback = yaml
+inventory = ./inventory

--- a/skale-nodes/ansible/roles/sync/templates/docker-compose.yml.j2
+++ b/skale-nodes/ansible/roles/sync/templates/docker-compose.yml.j2
@@ -42,7 +42,7 @@ services:
     volumes:
       - /var/run/skale:/var/run/skale
       - ${SKALE_DIR}:/skale_vol
-      - ${SKALE_DIR}/node_data:/skale_node_data
+      - ${SKALE_LIB_PATH}:${SKALE_LIB_PATH}
       - /etc/nft.conf.d/skale/chains:/etc/nft.conf.d/skale/chains
     healthcheck:
       test: ["CMD", "python3", "healthchecks/admin.py"]


### PR DESCRIPTION
This pull request introduces configuration improvements to the Ansible setup and updates the Docker Compose template to enhance flexibility in specifying library paths. The main changes are grouped into Ansible configuration enhancements and Docker Compose volume mapping updates.

**Ansible configuration enhancements:**

* Set the `inventory` option in `ansible.cfg` to `./inventory` to explicitly specify the inventory file location, improving clarity and reliability for Ansible runs.

**Docker Compose volume mapping updates:**

* Updated the `volumes` section in the Docker Compose template to use the `SKALE_LIB_PATH` environment variable for mounting the library path, replacing the previous hardcoded `node_data` directory. This change allows for greater flexibility and consistency across deployments.